### PR TITLE
Fix typo

### DIFF
--- a/posts/array-prototype-group-by-to-the-rescue.mdx
+++ b/posts/array-prototype-group-by-to-the-rescue.mdx
@@ -154,7 +154,7 @@ Object.values({
 
 ## Array.prototype.groupBy
 
-[TC39 committee](https://tc39.es/) is introducing the [Arrow Grouping proposal](https://github.com/tc39/proposal-array-grouping) (⚠️ Stage 3). 🎉
+[TC39 committee](https://tc39.es/) is introducing the [Array Grouping proposal](https://github.com/tc39/proposal-array-grouping) (⚠️ Stage 3). 🎉
 
 To start using this today, you will need a spec-compliant shim/polyfill for the `Array.prototype.groupBy` method: https://github.com/es-shims/Array.prototype.groupBy. It should also soon be available as part of `stage-3` preset.
 


### PR DESCRIPTION
This PR fixes a typo that references Arrow Grouping rather than Array Grouping.