### PR TITLE
refactor: export `PostFrontMatter` as the canonical post type

### DIFF
--- a/components/BlogLayout.tsx
+++ b/components/BlogLayout.tsx
@@ -1,4 +1,5 @@
 import Image from 'next/image';
+import type { ReactNode } from 'react';
 
 import { parseISO, format } from 'date-fns';
 import { SocialIcon as ReactSocialIcon } from 'react-social-icons/component';
@@ -6,6 +7,7 @@ import { SocialIcon as ReactSocialIcon } from 'react-social-icons/component';
 import Container from '@/components/Container';
 import CopyAsMarkdownButton from '@/components/CopyAsMarkdownButton';
 import styles from '@/styles/GradientAnimation.module.css';
+import type { PostFrontMatter } from '@/utils/mdx';
 import { openWindow } from '@/utils/openWindow';
 
 import { Comments } from './Comments';
@@ -29,7 +31,13 @@ function ShareSocialIcon({ network }: { network: string }) {
 const editUrl = (slug: string) =>
   `https://github.com/charpeni/charpeni.com/edit/main/posts/${slug}.mdx`;
 
-export default function BlogLayout({ children, frontMatter }) {
+export default function BlogLayout({
+  children,
+  frontMatter,
+}: {
+  children: ReactNode;
+  frontMatter: PostFrontMatter;
+}) {
   const postUrl = `https://charpeni.com/blog/${frontMatter.slug}`;
   // Posts may omit `image`. The in-page banner block is rendered only when
   // `image` is set. For social previews we prefer, in order:

--- a/components/BlogPostCard.tsx
+++ b/components/BlogPostCard.tsx
@@ -2,6 +2,7 @@ import Link from 'next/link';
 import { useMemo } from 'react';
 
 import type { LaneCell, RowGraph } from '@/utils/graph';
+import type { PostFrontMatter } from '@/utils/mdx';
 
 /**
  * Sentinel used in the highlight set to mark the main rail. Branch
@@ -10,13 +11,10 @@ import type { LaneCell, RowGraph } from '@/utils/graph';
  */
 export const MAIN_LANE = '__main__';
 
-type Props = {
-  title: string;
-  summary: string;
-  slug: string;
-  publishedAt: string;
-  readingTime: { text: string };
-  tags: string[];
+type Props = Pick<
+  PostFrontMatter,
+  'title' | 'summary' | 'slug' | 'publishedAt' | 'readingTime' | 'tags'
+> & {
   /**
    * Drawing directives for the rail at this row. When omitted the
    * card renders a plain main-only rail. Posts that carry a branch

--- a/pages/tags/[tag].tsx
+++ b/pages/tags/[tag].tsx
@@ -7,6 +7,7 @@ import Link from 'next/link';
 
 import Container from '@/components/Container';
 import { getAllPostsFrontMatter } from '@/utils/mdx';
+import type { PostMeta } from '@/utils/mdx';
 
 const SITE_URL = 'https://charpeni.com';
 
@@ -16,14 +17,10 @@ const dateFormatter = new Intl.DateTimeFormat('en-US', {
   day: 'numeric',
 });
 
-type TagPost = {
-  slug: string;
-  title: string;
-  summary: string;
-  publishedAt: string;
-  readingTime: { text: string };
-  tags: string[];
-};
+type TagPost = Pick<
+  PostMeta,
+  'slug' | 'title' | 'summary' | 'publishedAt' | 'readingTime' | 'tags'
+>;
 
 type Props = {
   tag: string;

--- a/scripts/generateLlmsTxt.ts
+++ b/scripts/generateLlmsTxt.ts
@@ -3,13 +3,15 @@ import path from 'node:path';
 
 import matter from 'gray-matter';
 
+import type { PostMeta as CanonicalPostMeta } from '../utils/mdx';
+
 const SITE_URL = 'https://charpeni.com';
 
-type PostMeta = {
-  slug: string;
-  title: string;
-  publishedAt: string;
-};
+/**
+ * The narrow slice this script reads, derived from the canonical
+ * {@link CanonicalPostMeta} in `utils/mdx.ts` so it can't drift.
+ */
+type PostMeta = Pick<CanonicalPostMeta, 'slug' | 'title' | 'publishedAt'>;
 
 function getPostsMeta(): PostMeta[] {
   const postsDir = path.join(process.cwd(), 'posts');

--- a/scripts/generateRssFeed.ts
+++ b/scripts/generateRssFeed.ts
@@ -3,6 +3,8 @@ import path from 'node:path';
 
 import matter from 'gray-matter';
 
+import type { PostMeta as CanonicalPostMeta } from '../utils/mdx';
+
 const SITE_URL = 'https://charpeni.com';
 const AUTHOR_NAME = 'Nicolas Charpentier';
 const AUTHOR_EMAIL = 'blog@nicolascharpentier.com';
@@ -16,20 +18,16 @@ const MIME_TYPES = {
   '.svg': 'image/svg+xml',
 } as const;
 
-type PostMeta = {
-  slug: string;
-  title: string;
-  publishedAt: string;
-  updatedAt?: string;
-  summary: string;
-  /**
-   * Optional banner image (relative to `/public`). When omitted, the RSS
-   * `<enclosure>` is skipped — RSS readers that don't get an enclosure simply
-   * render the item without a thumbnail.
-   */
-  image?: string;
-  tags: string[];
-};
+/**
+ * The fields this script reads from a post's front matter. Derived from the
+ * canonical {@link CanonicalPostMeta} so the RSS shape can't drift from the
+ * source of truth in `utils/mdx.ts`. `image` is optional: when omitted, the
+ * RSS `<enclosure>` is skipped and readers render the item without a thumbnail.
+ */
+type PostMeta = Pick<
+  CanonicalPostMeta,
+  'slug' | 'title' | 'publishedAt' | 'updatedAt' | 'summary' | 'image' | 'tags'
+>;
 
 function escapeXml(text: string): string {
   return text

--- a/utils/mdx.ts
+++ b/utils/mdx.ts
@@ -15,7 +15,7 @@ import rehypeSlug from 'rehype-slug';
 import type { MDXRemoteSerializeResult } from 'next-mdx-remote';
 import type { ReadTimeResults } from 'reading-time';
 
-type PostFrontMatter = {
+export type PostFrontMatter = {
   title: string;
   publishedAt: string;
   /**
@@ -61,6 +61,26 @@ type PostFrontMatter = {
    */
   blurDataURL?: string;
 };
+
+/**
+ * The metadata-only slice of {@link PostFrontMatter} — the fields shared by
+ * list views, cards, and the build-time scripts (RSS, llms.txt). Consumers
+ * that only need to render or syndicate post metadata should `Pick` from this
+ * rather than redeclaring their own shape. Build scripts that run outside the
+ * bundler (`node --experimental-strip-types`) can `import type` this safely:
+ * it carries no runtime dependency on this module's MDX/plaiceholder imports.
+ */
+export type PostMeta = Pick<
+  PostFrontMatter,
+  | 'slug'
+  | 'title'
+  | 'summary'
+  | 'publishedAt'
+  | 'updatedAt'
+  | 'image'
+  | 'tags'
+  | 'readingTime'
+>;
 
 type Post = {
   mdxSource: MDXRemoteSerializeResult;


### PR DESCRIPTION
`PostFrontMatter` in `utils/mdx.ts` was well-documented but never exported, so five consumers each redefined a partial copy — and `BlogLayout`'s `frontMatter` prop was implicitly `any`.

This exports `PostFrontMatter` and a `PostMeta` slice as the single source of truth. Consumers now `Pick` from them instead of redeclaring, and `BlogLayout` is typed (removing the `any` across ~12 accesses).

- Export `PostFrontMatter` + add `PostMeta` in `utils/mdx.ts`
- Type `BlogLayout`'s `frontMatter` prop
- Derive `BlogPostCard` / tag-page types from the canonical type
- Build scripts derive their types via `import type` (strips cleanly outside the bundler)

No runtime changes. Verified: `type-check`, `lint`, and `build` + `postbuild` all pass.