### PR TITLE
Enable TypeScript strict mode

### DIFF
--- a/scripts/generateRssFeed.ts
+++ b/scripts/generateRssFeed.ts
@@ -80,7 +80,8 @@ function generateRssItem(post: PostMeta): string {
     const imagePath = path.join(process.cwd(), 'public', post.image);
     const imageSize = fs.statSync(imagePath).size;
     const ext = path.extname(post.image).toLowerCase();
-    const mimeType = MIME_TYPES[ext] ?? 'application/octet-stream';
+    const mimeType =
+      MIME_TYPES[ext as keyof typeof MIME_TYPES] ?? 'application/octet-stream';
     enclosure = `\n      <enclosure url="${escapeXml(imageUrl)}" length="${imageSize}" type="${mimeType}" />`;
   }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
-    "strict": false,
+    "strict": true,
     "forceConsistentCasingInFileNames": true,
     "noEmit": true,
     "esModuleInterop": true,
@@ -26,8 +26,7 @@
       {
         "name": "next"
       }
-    ],
-    "strictNullChecks": true
+    ]
   },
   "exclude": ["node_modules", ".next", "out"],
   "include": [


### PR DESCRIPTION
Turns on `strict` in `tsconfig.json` (and drops the now-redundant `strictNullChecks`).

The only blocker was a single `noImplicitAny` error in `scripts/generateRssFeed.ts`, where `MIME_TYPES` was indexed with a plain `string`. Fixed by typing the lookup as `keyof typeof MIME_TYPES`; the fallback behavior is unchanged.

`pnpm type-check` and `pnpm lint` both pass.