### PR TITLE
Upgrade pnpm 10.24.0 → 11.5.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "author": "Nicolas Charpentier <nicolas.charpentier079@gmail.com>",
   "license": "MIT",
-  "packageManager": "pnpm@10.24.0",
+  "packageManager": "pnpm@11.5.3+sha512.7ac1c919341c213a34dc0d02afb7143c5c26ac26ee8c4782deea821b8ac64d2134a081fd8941dae6e29bbb48f58dfc2b7fbceeccc07cb2f09d219d342a4969ed",
   "scripts": {
     "analyze": "ANALYZE=true pnpm build",
     "build": "next build",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,4 @@
+allowBuilds:
+  es5-ext: false
+  sharp: false
+  unrs-resolver: false


### PR DESCRIPTION
Bumps the `packageManager` field to pnpm 11.5.3.

pnpm 11 treats unreviewed dependency build scripts as a hard error (`strictDepBuilds` now defaults to `true`) and replaces the `onlyBuiltDependencies`/`ignoredBuiltDependencies` settings with the `allowBuilds` map in `pnpm-workspace.yaml`.

Adds `pnpm-workspace.yaml` marking `es5-ext`, `sharp`, and `unrs-resolver` build scripts as not built — preserving the prior pnpm 10 behavior where these scripts were skipped.

`pnpm-lock.yaml` is unchanged (lockfile v9.0 is compatible). `pnpm install`, `pnpm type-check`, `pnpm lint`, and `pnpm build` all pass under pnpm 11.5.3.