### PR TITLE
Update pinned GitHub Actions with pinact

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -13,11 +13,11 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Install pnpm
-        uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
       - name: Use Node.js
-        uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
           cache: 'pnpm'
@@ -29,11 +29,11 @@ jobs:
   type-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Install pnpm
-        uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
       - name: Use Node.js
-        uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
           cache: 'pnpm'


### PR DESCRIPTION
Updates all GitHub Actions to their latest releases via `pinact run --update`, keeping them pinned to full commit SHAs.

| Action | From | To |
| --- | --- | --- |
| `actions/checkout` | v5.0.0 | v6.0.3 |
| `pnpm/action-setup` | v4.2.0 | v6.0.8 |
| `actions/setup-node` | v6.0.0 | v6.4.0 |

Notes on the major bumps:
- **`pnpm/action-setup` v4 → v6** adds pnpm 11 support (relevant now that the repo is on pnpm 11.5.3) and runs on Node 24. No config changes needed — version is resolved from the `packageManager` field.
- **`actions/checkout` v5 → v6** moves to the Node 24 runtime; no workflow-facing config changes.
- **`actions/setup-node` v6.4.0** — the explicit `cache: 'pnpm'` is unaffected by v6's change to automatic-caching defaults (that only applies when no `cache` input is given).

Verified with `pinact run --verify` (all SHAs resolve to their commented versions).