### PR TITLE
Convert Static Analysis workflow to a matrix

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -10,8 +10,17 @@ permissions:
   contents: read
 
 jobs:
-  lint:
+  ci:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - task: lint
+            command: pnpm lint
+          - task: type-check
+            command: pnpm type-check
+    name: ${{ matrix.task }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Install pnpm
@@ -23,21 +32,5 @@ jobs:
           cache: 'pnpm'
       - name: Install dependencies
         run: pnpm install
-      - name: Run linter
-        run: pnpm lint
-
-  type-check:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-      - name: Install pnpm
-        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
-      - name: Use Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          node-version: 22
-          cache: 'pnpm'
-      - name: Install dependencies
-        run: pnpm install
-      - name: Run type checking
-        run: pnpm type-check
+      - name: ${{ matrix.task }}
+        run: ${{ matrix.command }}


### PR DESCRIPTION
Collapses the two duplicated jobs (`lint` and `type-check`) into a single matrixed `ci` job, modeled on [charpeni/one-of's CI workflow](https://github.com/charpeni/one-of/blob/main/.github/workflows/ci.yml).

- `fail-fast: false` so a failure in one task doesn't cancel the other.
- `name: ${{ matrix.task }}` preserves the existing per-task check names (`lint`, `type-check`).
- Same pinned action SHAs and Node 22 as before — no change to CI coverage, just structure (removes the duplicated checkout/pnpm/node setup).

Validated with `actionlint`.