### PR TITLE
Memoize `getPostBySlug` to speed up builds

### DIFF
--- a/utils/mdx.ts
+++ b/utils/mdx.ts
@@ -93,7 +93,44 @@ export function getPosts() {
   return fs.readdirSync(path.join(root, 'posts'));
 }
 
-export async function getPostBySlug(slug: string): Promise<Post> {
+/**
+ * Build-time memo cache for {@link getPostBySlug}, keyed by slug.
+ *
+ * Compiling a post is expensive — `serialize()` runs the full MDX pipeline
+ * (syntax highlighting via `rehype-prism-plus`, autolinked headings, callouts)
+ * and `getPlaiceholder()` decodes the banner image. The same posts are
+ * otherwise recompiled many times per build: `getAllPostsFrontMatter()` reads
+ * every post and is itself called once on the homepage plus once per tag in
+ * `pages/tags/[tag].tsx`'s `getStaticPaths`/`getStaticProps`, so a single build
+ * compiles each post on the order of dozens of times.
+ *
+ * We cache the in-flight Promise (not the resolved value) so concurrent callers
+ * — e.g. the `Promise.all` fan-out in `getAllPostsFrontMatter()` — share one
+ * compilation rather than racing to start their own.
+ *
+ * This is safe because post content is immutable for the lifetime of a build
+ * process (SSG runs to completion, then exits). The trade-off is that a long
+ * lived `next dev` process won't pick up edits to a post body until restarted.
+ */
+const postCache = new Map<string, Promise<Post>>();
+
+export function getPostBySlug(slug: string): Promise<Post> {
+  const cached = postCache.get(slug);
+  if (cached) {
+    return cached;
+  }
+
+  // Evict on failure so a transient error doesn't poison the cache for the
+  // rest of the build; the resolved value is what we want to keep around.
+  const promise = loadPostBySlug(slug).catch((error: unknown) => {
+    postCache.delete(slug);
+    throw error;
+  });
+  postCache.set(slug, promise);
+  return promise;
+}
+
+async function loadPostBySlug(slug: string): Promise<Post> {
   const source = fs.readFileSync(
     path.join(root, 'posts', `${slug}.mdx`),
     'utf8',


### PR DESCRIPTION
## Why

Building `/tags/` was slow. Each tag page calls `getAllPostsFrontMatter()`, which compiles **every** post via `getPostBySlug` — running the full MDX pipeline (`serialize` with `rehype-prism-plus` syntax highlighting, autolinked headings, callouts) plus `getPlaiceholder` image decoding — and then keeps only the frontmatter.

That helper runs once on the homepage and **once per tag** (in `getStaticPaths` + each `getStaticProps`). With 34 posts and 24 tags, the same posts were recompiled dozens of times per build.

## What

Memoize `getPostBySlug` with a module-level cache keyed by slug:

- Cache the **in-flight Promise** (not the resolved value) so the `Promise.all` fan-out in `getAllPostsFrontMatter` shares one compile per post instead of racing.
- **Evict on failure** so a transient error can't poison the cache for the rest of the build.
- Public signature is unchanged, so no call sites needed edits (`pages/index.tsx`, `pages/tags/[tag].tsx`, `pages/blog/[slug].tsx`).

The cache lives for the build process lifetime, which is safe since post content is immutable during a build. Trade-off: a long-running `next dev` won't pick up edits to a post body until restarted.

## Impact (local `pnpm build`)

| | per tag page | total build |
| --- | --- | --- |
| before | ~13,020 ms | ~45s |
| after | ~3,070 ms | ~18s |

Note: Next.js prerenders across multiple worker processes and a module-level cache isn't shared across workers, so each worker still pays one cold compile per post it touches. A cross-worker (on-disk) cache could go further but is a larger, separate change.

## Verification

- `pnpm type-check` ✓
- `pnpm lint` ✓
- Full build succeeds; output unchanged (34 posts, sitemap / llms.txt / RSS all generated).