### PR TITLE
Inline build artifact generation

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-enable-pre-post-scripts=true

--- a/package.json
+++ b/package.json
@@ -7,8 +7,7 @@
   "packageManager": "pnpm@11.5.3+sha512.7ac1c919341c213a34dc0d02afb7143c5c26ac26ee8c4782deea821b8ac64d2134a081fd8941dae6e29bbb48f58dfc2b7fbceeccc07cb2f09d219d342a4969ed",
   "scripts": {
     "analyze": "ANALYZE=true pnpm build",
-    "build": "next build",
-    "postbuild": "next-sitemap && node --experimental-strip-types scripts/generateLlmsTxt.mts && node --experimental-strip-types scripts/generateRssFeed.mts",
+    "build": "next build && next-sitemap && node scripts/generateLlmsTxt.mts && node scripts/generateRssFeed.mts",
     "dev": "next",
     "start": "next start",
     "type-check": "tsc --pretty --noEmit",

--- a/scripts/generateOgDefault.ts
+++ b/scripts/generateOgDefault.ts
@@ -4,7 +4,7 @@
  * the `image` prop on `<Container>` (homepage, /disclaimer, /privacy-policy).
  *
  * Run manually after editing the SVG below:
- *   node --experimental-strip-types scripts/generateOgDefault.ts
+ *   node scripts/generateOgDefault.ts
  *
  * Then commit the regenerated PNG.
  *

--- a/scripts/generateOgImages.ts
+++ b/scripts/generateOgImages.ts
@@ -9,7 +9,7 @@
  * article title instead of the generic sitewide card.
  *
  * Run manually after adding or renaming a post:
- *   node --experimental-strip-types scripts/generateOgImages.ts
+ *   node scripts/generateOgImages.ts
  *
  * Then commit the regenerated PNG(s). Like `og-default.png`, these are
  * committed to the repo so the build pipeline never has to rasterize text —

--- a/utils/mdx.ts
+++ b/utils/mdx.ts
@@ -66,8 +66,8 @@ export type PostFrontMatter = {
  * The metadata-only slice of {@link PostFrontMatter} — the fields shared by
  * list views, cards, and the build-time scripts (RSS, llms.txt). Consumers
  * that only need to render or syndicate post metadata should `Pick` from this
- * rather than redeclaring their own shape. Build scripts that run outside the
- * bundler (`node --experimental-strip-types`) can `import type` this safely:
+ * rather than redeclaring their own shape. Build scripts that run directly
+ * with `node` can `import type` this safely:
  * it carries no runtime dependency on this module's MDX/plaiceholder imports.
  */
 export type PostMeta = Pick<


### PR DESCRIPTION
## Summary
- Inline the previous `postbuild` artifact generation into `build`.
- Remove `.npmrc` so `pnpm` lifecycle hooks are not enabled project-wide.
- Rely on the existing `.nvmrc` Node `24` pin and stable built-in type stripping instead of `--experimental-strip-types`.
- Preserve generation of `next-sitemap`, `llms.txt`, and the RSS feed after `next build`.

## Rationale
This reduces lifecycle-script security surface. The project previously needed `.npmrc` with `enable-pre-post-scripts=true` so `pnpm` would automatically run `postbuild`, but that setting enables automatic `pre*`/`post*` lifecycle script execution broadly for the project. Inlining the commands keeps the same build output while making the generated artifacts explicit in `build`.

Node `24` supports built-in TypeScript type stripping for `.mts`/`.ts` files, and the repo already pins Node `24` via `.nvmrc`, so the build no longer needs `--experimental-strip-types` or duplicate `engines` configuration.

## Verification
- Rebased onto current `origin/main`.
- `node scripts/generateLlmsTxt.mts` was not fully runnable in this worktree because `node_modules` is missing.
- `node scripts/generateRssFeed.mts` was not fully runnable in this worktree because `node_modules` is missing.
- `pnpm lint` could not run because `node_modules` is missing in this worktree: `eslint: not found`.