### PR TITLE
Add retro terminal mode

### DIFF
--- a/components/BlogLayout.tsx
+++ b/components/BlogLayout.tsx
@@ -118,7 +118,7 @@ export default function BlogLayout({
     >
       <article className="flex flex-col justify-center max-w-3xl mx-auto mb-16 w-full">
         <header className="mb-6 lg:mb-12">
-          <h1 className="font-bold text-3xl md:text-4xl lg:text-5xl tracking-tight text-black dark:text-white">
+          <h1 className="font-black text-3xl md:text-4xl lg:text-5xl leading-tight tracking-tight text-black dark:text-white">
             {frontMatter.title}
           </h1>
         </header>

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -3,12 +3,15 @@ import { useState, useEffect } from 'react';
 
 import { useTheme } from 'next-themes';
 
+import { useRetroMode } from '@/components/RetroModeContext';
+
 import { Moon } from './Moon';
 import { Sun } from './Sun';
 
 export default function Header() {
   const [mounted, setMounted] = useState(false);
   const { resolvedTheme, setTheme } = useTheme();
+  const { isRetro, toggleRetro } = useRetroMode();
 
   // After mounting, we have access to the theme
   // eslint-disable-next-line react-hooks/set-state-in-effect
@@ -24,7 +27,16 @@ export default function Header() {
       >
         {mounted ? resolvedTheme === 'dark' ? <Sun /> : <Moon /> : null}
       </button>
-      <div>
+      <div className="flex items-center gap-3">
+        <button
+          type="button"
+          className={`retro-mode-trigger retro-mode-trigger--${isRetro ? 'retro' : 'normal'}`}
+          onClick={toggleRetro}
+          aria-label={isRetro ? 'Exit retro mode' : 'ssh blog@charpeni.com'}
+          title={isRetro ? 'Exit retro mode' : 'ssh blog@charpeni.com'}
+        >
+          <span aria-hidden="true">&gt;_</span>
+        </button>
         <Link href="/" className="p-2 sm:p-4 text-gray-900 dark:text-gray-100">
           Home
         </Link>

--- a/components/LegalContent.tsx
+++ b/components/LegalContent.tsx
@@ -1,0 +1,95 @@
+import NextLink from 'next/link';
+
+type LegalContentProps = {
+  variant: 'disclaimer' | 'privacy-policy';
+};
+
+export const LEGAL_TITLES: Record<LegalContentProps['variant'], string> = {
+  disclaimer: 'DISCLAIMER',
+  'privacy-policy': 'PRIVACY POLICY',
+};
+
+export function LegalContent({ variant }: LegalContentProps) {
+  if (variant === 'privacy-policy') {
+    return (
+      <>
+        <p>
+          This website (<a href="https://charpeni.com">https://charpeni.com</a>) does not
+          directly collect personal data on behalf of its author (Nicolas
+          Charpentier) and uses no cookies.
+        </p>
+        <p className="mt-4">
+          This website is hosted on Vercel (<a href="https://vercel.com">https://vercel.com</a>).
+          As such, when loading this website, your IP address will be available
+          to Vercel and may be stored in their access logs, along with the
+          information which page specifically you loaded.
+        </p>
+        <p className="mt-4">
+          From this website, you can visit other websites by following hyperlinks
+          to such external sites. These other sites may have different privacy
+          policies and terms which are beyond control of the author of{' '}
+          <a href="https://charpeni.com">https://charpeni.com</a>. See this
+          website&apos;s <NextLink href="/disclaimer">Legal Disclaimer</NextLink> for
+          more information.
+        </p>
+      </>
+    );
+  }
+
+  return (
+    <>
+      <h2 className="prose font-bold">WEBSITE DISCLAIMER</h2>
+      <p>
+        The information provided by Nicolas Charpentier (&quot;we&quot;, &quot;us&quot;,
+        &quot;our&quot;) on <a href="https://charpeni.com">https://charpeni.com</a> (the
+        &quot;Site&quot;) is for general informational purposes only. All information
+        on the Site is provided in good faith, however we make no representation
+        or warranty of any kind, express or implied, regarding the accuracy,
+        adequacy, validity, reliability, availability or completeness of any
+        information on the Site. UNDER NO CIRCUMSTANCE SHALL WE HAVE ANY
+        LIABILITY TO YOU FOR ANY LOSS OR DAMAGE OF ANY KIND INCURRED AS A RESULT
+        OF THE USE OF THE SITE OR RELIANCE ON ANY INFORMATION PROVIDED ON THE
+        SITE. YOUR USE OF THIS SITE AND YOUR RELIANCE ON ANY INFORMATION ON THE
+        SITE IS SOLELY AT YOUR OWN RISK.
+      </p>
+      <h2 className="prose mt-4 font-bold">EXTERNAL LINKS DISCLAIMER</h2>
+      <p>
+        The Site may contain (or you may be sent through the Site) links to other
+        websites or content belonging to or originating from third parties or
+        links to websites and features in banners or other advertising. Such
+        external links are not investigated, monitored, or checked for accuracy,
+        adequacy, validity, reliability, availability or completeness by us. WE
+        DO NOT WARRANT, ENDORSE, GUARANTEE, OR ASSUME RESPONSIBILITY FOR THE
+        ACCURACY OR RELIABILITY OF ANY INFORMATION OFFERED BY THIRD-PARTY
+        WEBSITES LINKED THROUGH THE SITE OR ANY WEBSITE OR FEATURE LINKED IN ANY
+        BANNER OR OTHER ADVERTISING. WE WILL NOT BE A PARTY TO OR IN ANY WAY BE
+        RESPONSIBLE FOR MONITORING ANY TRANSACTION BETWEEN YOU AND THIRD-PARTY
+        PROVIDERS OF PRODUCTS OR SERVICES.
+      </p>
+      <h2 className="prose mt-4 font-bold">TESTIMONIALS DISCLAIMER</h2>
+      <p className="mb-4">
+        The Site may contain testimonials by users of our products and/or
+        services. These testimonials reflect the real-life experiences and
+        opinions of such users. However, the experiences are personal to those
+        particular users, and may not necessarily be representative of all users
+        of our products and/or services. We do not claim, and you should not
+        assume, that all users will have the same experiences. YOUR INDIVIDUAL
+        RESULTS MAY VARY.
+      </p>
+      <p className="mb-4">
+        The testimonials on the Site are submitted in various forms such as text,
+        audio and/or video, and are reviewed by us before being posted. They
+        appear on the Site verbatim as given by the users, except for the
+        correction of grammar or typing errors. Some testimonials may have been
+        shortened for the sake of brevity where the full testimonial contained
+        extraneous information not relevant to the general public.
+      </p>
+      <p>
+        The views and opinions contained in the testimonials belong solely to the
+        individual user and do not reflect our views and opinions. We are not
+        affiliated with users who provide testimonials, and users are not paid or
+        otherwise compensated for their testimonials.
+      </p>
+    </>
+  );
+}

--- a/components/RetroModeContext.tsx
+++ b/components/RetroModeContext.tsx
@@ -1,0 +1,60 @@
+'use client';
+
+import { createContext, useCallback, useContext, useEffect, useState } from 'react';
+
+const COOKIE_NAME = 'retro-os';
+const ONE_YEAR = 60 * 60 * 24 * 365;
+
+type RetroModeContextValue = {
+  isRetro: boolean;
+  toggleRetro: () => void;
+  setRetro: (value: boolean) => void;
+};
+
+const RetroModeContext = createContext<RetroModeContextValue>({
+  isRetro: false,
+  toggleRetro: () => {},
+  setRetro: () => {},
+});
+
+export function useRetroMode() {
+  return useContext(RetroModeContext);
+}
+
+function readCookie(name: string): boolean {
+  if (typeof document === 'undefined') return false;
+  const match = document.cookie.match(
+    new RegExp(`(?:^|; )${name}=([^;]*)`),
+  );
+  return match ? match[1] === '1' : false;
+}
+
+function writeCookie(name: string, value: boolean) {
+  if (typeof document === 'undefined') return;
+  // eslint-disable-next-line unicorn/no-document-cookie
+  document.cookie = `${name}=${value ? '1' : '0'}; path=/; max-age=${ONE_YEAR}; samesite=lax`;
+}
+
+export function RetroModeProvider({ children }: { children: React.ReactNode }) {
+  const [isRetro, setIsRetro] = useState(false);
+
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setIsRetro(readCookie(COOKIE_NAME));
+  }, []);
+
+  const setRetro = useCallback((value: boolean) => {
+    setIsRetro(value);
+    writeCookie(COOKIE_NAME, value);
+  }, []);
+
+  const toggleRetro = useCallback(() => {
+    setRetro(!isRetro);
+  }, [isRetro, setRetro]);
+
+  return (
+    <RetroModeContext.Provider value={{ isRetro, toggleRetro, setRetro }}>
+      {children}
+    </RetroModeContext.Provider>
+  );
+}

--- a/components/RetroTerminal.tsx
+++ b/components/RetroTerminal.tsx
@@ -49,6 +49,7 @@ function readStoredTerminalState(): StoredTerminalState | null {
 }
 
 function storedShowWindows(posts: PostFrontMatter[], stored: StoredTerminalState | null, vw: number, vh: number): WinState[] {
+  if (vw < 640) return [];
   const slugs = new Set(posts.map((post) => post.slug));
   return (stored?.windows ?? [])
     .filter((win) => win.id.startsWith('show:') && slugs.has(win.id.slice('show:'.length)))
@@ -156,7 +157,7 @@ export default function RetroTerminal({
     setStates((prev) => {
       const z = maxZof(prev) + 1;
       if (prev[id]) return { ...prev, [id]: { ...prev[id], ...geom, z } };
-      const offset = (Object.keys(prev).length % 6) * 22;
+      const offset = id.startsWith('show:') ? 0 : (Object.keys(prev).length % 6) * 22;
       return { ...prev, [id]: { id, x: geom.x + offset, y: geom.y + offset, w: geom.w, h: geom.h, z } };
     });
   }, []);
@@ -459,6 +460,7 @@ export default function RetroTerminal({
                   cursor={cursor}
                   onSelect={setCursor}
                   onOpen={openAt}
+                  isMobile={vw < 900}
                   contentRef={contentRef}
                 />
                 <div className="retro-terminal-status">

--- a/components/RetroTerminal.tsx
+++ b/components/RetroTerminal.tsx
@@ -122,6 +122,7 @@ export default function RetroTerminal({
   const [mdxBySlug, setMdxBySlug] = useState<Record<string, MdxState>>({});
   const loadingSlugs = useRef(new Set<string>());
   const contentRef = useRef<HTMLDivElement | null>(null);
+  const termWindowRef = useRef<HTMLDivElement | null>(null);
   const { setRetro } = useRetroMode();
 
   useEffect(() => {
@@ -376,8 +377,7 @@ export default function RetroTerminal({
 
   useEffect(() => {
     if (windows.find((win) => win.focused)?.id !== TERM_ID) return;
-    const term = document.querySelector<HTMLElement>(`[data-retro-window-id="${TERM_ID}"]`);
-    term?.focus({ preventScroll: true });
+    termWindowRef.current?.focus({ preventScroll: true });
   }, [windows]);
 
   const onLogKeyDown = (e: React.KeyboardEvent) => {
@@ -454,6 +454,8 @@ export default function RetroTerminal({
                 onActivate={() => focus(win.id)}
                 onKeyDown={onLogKeyDown}
                 onTitleDoubleClick={() => resetWindow(win.id)}
+                windowRef={termWindowRef}
+                compact={vw < 640}
               >
                 <GraphLog
                   posts={posts}
@@ -493,6 +495,7 @@ export default function RetroTerminal({
                 resizeProps={resizeHandleProps(win.id)}
                 onOpenBlogLink={openBlogSlug}
                 onTitleDoubleClick={() => resetWindow(win.id)}
+                compact={vw < 640}
               />
             );
           }
@@ -507,6 +510,7 @@ export default function RetroTerminal({
                 dragProps={titleDragProps(win.id)}
                 resizeProps={resizeHandleProps(win.id)}
                 onTitleDoubleClick={() => resetWindow(win.id)}
+                compact={vw < 640}
               />
             );
           }
@@ -525,6 +529,7 @@ export default function RetroTerminal({
                 dragProps={titleDragProps(win.id)}
                 resizeProps={resizeHandleProps(win.id)}
                 onTitleDoubleClick={() => resetWindow(win.id)}
+                compact={vw < 640}
               />
             );
           }
@@ -533,16 +538,12 @@ export default function RetroTerminal({
 
         {/* exit button — top-right corner, fits the cream theme */}
         <button
-          className="retro-toggle retro-toggle--retro"
+          className="retro-toggle retro-toggle--retro retro-terminal-exit"
           onClick={() => {
-            // Exit back to the route that entered retro mode. Internal terminal
-            // navigation uses history.replaceState, so reload after restoring it
-            // to make Next render the page that matches the intended URL.
             setRetro(false);
             globalThis.history.replaceState(globalThis.history.state, '', entryPath.current);
             globalThis.location.reload();
           }}
-          style={{ position: 'absolute', top: 12, right: 12, zIndex: 99_999, height: 32 }}
           aria-label="Exit terminal mode"
         >
           <span className="retro-toggle-dot" />

--- a/components/RetroTerminal.tsx
+++ b/components/RetroTerminal.tsx
@@ -1,0 +1,552 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+import { DesktopFooter, DesktopProfile } from '@/components/retro-terminal/DesktopChrome';
+import {
+  MIN_H,
+  MIN_W,
+  PRS_WINDOW_MAX_H,
+  clampWinToViewport,
+  legalGeom,
+  maxWindowHeight,
+  prsGeom,
+  showGeom,
+  termGeom,
+} from '@/components/retro-terminal/geometry';
+import { GraphLog } from '@/components/retro-terminal/GraphLog';
+import { PRS_ID, STORAGE_KEY, TERM_ID, legalWinId, showWinId } from '@/components/retro-terminal/ids';
+import { LatestPrsWindow } from '@/components/retro-terminal/LatestPrsWindow';
+import { LegalWindow } from '@/components/retro-terminal/LegalWindow';
+import { branchOf } from '@/components/retro-terminal/postUtils';
+import { ShowTermWindow } from '@/components/retro-terminal/ShowWindow';
+import { TermWindow } from '@/components/retro-terminal/TermWindow';
+import type { LegalWindowVariant, MdxState, OpenWin, StoredTerminalState, WinGeom, WinState } from '@/components/retro-terminal/types';
+import { useRetroMode } from '@/components/RetroModeContext';
+import type { PostFrontMatter } from '@/utils/mdx';
+
+import type { MDXRemoteSerializeResult } from 'next-mdx-remote';
+
+function maxZof(states: Record<string, WinState>): number {
+  let max = 0;
+  for (const w of Object.values(states)) {
+    if (w.z > max) max = w.z;
+  }
+  return max;
+}
+
+function readStoredTerminalState(): StoredTerminalState | null {
+  if (globalThis.localStorage === undefined) return null;
+  try {
+    const raw = globalThis.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as StoredTerminalState;
+    if (!parsed || typeof parsed !== 'object') return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+function storedShowWindows(posts: PostFrontMatter[], stored: StoredTerminalState | null, vw: number, vh: number): WinState[] {
+  const slugs = new Set(posts.map((post) => post.slug));
+  return (stored?.windows ?? [])
+    .filter((win) => win.id.startsWith('show:') && slugs.has(win.id.slice('show:'.length)))
+    .map((win) => clampWinToViewport(win, vw, vh));
+}
+
+function initialPostSlug(posts: PostFrontMatter[]): string | null {
+  if (globalThis.location === undefined) return null;
+  const { pathname } = new URL(globalThis.location.href);
+  const match = /^\/blog\/([^/]+)$/.exec(pathname);
+  const slug = match ? decodeURIComponent(match[1]) : null;
+  return slug && posts.some((post) => post.slug === slug) ? slug : null;
+}
+
+function updatePostUrl(slug: string | null) {
+  if (globalThis.location === undefined || globalThis.history === undefined) return;
+  const nextPath = slug ? `/blog/${slug}` : '/';
+  globalThis.history.replaceState(globalThis.history.state, '', nextPath);
+}
+
+function currentPathWithSearchAndHash() {
+  if (globalThis.location === undefined) return '/';
+  const { pathname, search, hash } = new URL(globalThis.location.href);
+  return `${pathname}${search}${hash}`;
+}
+
+function useViewport() {
+  const [size, setSize] = useState(() => ({
+    w: typeof globalThis.innerWidth === 'number' ? globalThis.innerWidth : 1200,
+    h: typeof globalThis.innerHeight === 'number' ? globalThis.innerHeight : 800,
+  }));
+  useEffect(() => {
+    const update = () => setSize({ w: globalThis.innerWidth, h: globalThis.innerHeight });
+    update();
+    globalThis.addEventListener('resize', update);
+    return () => globalThis.removeEventListener('resize', update);
+  }, []);
+  return size;
+}
+
+export default function RetroTerminal({
+  posts,
+}: {
+  posts: PostFrontMatter[];
+}) {
+  const { w: vw, h: vh } = useViewport();
+  const bounds: WinGeom = { x: 0, y: 0, w: vw, h: vh };
+  const stored = useMemo(() => readStoredTerminalState(), []);
+  const urlPostSlug = useMemo(() => initialPostSlug(posts), [posts]);
+  const entryPath = useRef(currentPathWithSearchAndHash());
+
+  const [states, setStates] = useState<Record<string, WinState>>(() => {
+    const g = termGeom(vw, vh, posts);
+    const next: Record<string, WinState> = { [TERM_ID]: { id: TERM_ID, ...g, z: 1 } };
+    for (const win of storedShowWindows(posts, stored, vw, vh)) {
+      next[win.id] = win;
+    }
+    if (urlPostSlug) {
+      const id = showWinId(urlPostSlug);
+      next[id] = { ...(next[id] ?? { id, ...showGeom(vw, vh) }), z: maxZof(next) + 1 };
+    }
+    return next;
+  });
+  const [cursor, setCursor] = useState(() => {
+    const urlPostIndex = urlPostSlug ? posts.findIndex((post) => post.slug === urlPostSlug) : -1;
+    if (urlPostIndex >= 0) return urlPostIndex;
+    const storedCursor = stored?.cursor;
+    return typeof storedCursor === 'number' && storedCursor >= 0 && storedCursor < posts.length ? storedCursor : 0;
+  });
+  const [mdxBySlug, setMdxBySlug] = useState<Record<string, MdxState>>({});
+  const loadingSlugs = useRef(new Set<string>());
+  const contentRef = useRef<HTMLDivElement | null>(null);
+  const { setRetro } = useRetroMode();
+
+  useEffect(() => {
+    const recenterTerminal = () => {
+      const g = termGeom(globalThis.innerWidth, globalThis.innerHeight, posts);
+      setStates((prev) => {
+        const term = prev[TERM_ID];
+        if (!term) return prev;
+        return { ...prev, [TERM_ID]: { ...term, ...g } };
+      });
+    };
+    globalThis.addEventListener('resize', recenterTerminal);
+    return () => globalThis.removeEventListener('resize', recenterTerminal);
+  }, [posts]);
+
+  useEffect(() => {
+    if (globalThis.localStorage === undefined) return;
+    const windows = Object.values(states).filter((win) => win.id.startsWith('show:'));
+    globalThis.localStorage.setItem(STORAGE_KEY, JSON.stringify({ cursor, windows }));
+  }, [cursor, states]);
+
+  const focus = useCallback((id: string) => {
+    setStates((prev) => {
+      const w = prev[id];
+      if (!w) return prev;
+      const z = maxZof(prev) + 1;
+      if (w.z === z - 1) return prev;
+      return { ...prev, [id]: { ...w, z } };
+    });
+  }, []);
+
+  const open = useCallback((id: string, geom: WinGeom) => {
+    setStates((prev) => {
+      const z = maxZof(prev) + 1;
+      if (prev[id]) return { ...prev, [id]: { ...prev[id], ...geom, z } };
+      const offset = (Object.keys(prev).length % 6) * 22;
+      return { ...prev, [id]: { id, x: geom.x + offset, y: geom.y + offset, w: geom.w, h: geom.h, z } };
+    });
+  }, []);
+
+  const close = useCallback((id: string) => {
+    setStates((prev) => {
+      if (!prev[id]) return prev;
+      const next = { ...prev };
+      delete next[id];
+      return next;
+    });
+  }, []);
+
+  const closeShow = useCallback((id: string) => {
+    close(id);
+    const slug = id.slice('show:'.length);
+    if (globalThis.location !== undefined) {
+      const currentPath = new URL(globalThis.location.href).pathname;
+      const currentSlug = currentPath === `/blog/${slug}` ? slug : null;
+      if (currentSlug === slug) updatePostUrl(null);
+    }
+  }, [close]);
+
+  const move = useCallback((id: string, x: number, y: number) => {
+    setStates((prev) => {
+      const w = prev[id];
+      if (!w) return prev;
+      const cx = Math.max(0, Math.min(x, bounds.w - 40));
+      const cy = Math.max(0, Math.min(y, bounds.h - 24));
+      return { ...prev, [id]: { ...w, x: cx, y: cy } };
+    });
+  }, [bounds.w, bounds.h]);
+
+  const resize = useCallback((id: string, w: number, h: number) => {
+    setStates((prev) => {
+      const win = prev[id];
+      if (!win) return prev;
+      const cw = Math.max(MIN_W, Math.min(w, bounds.w - win.x));
+      const maxHeight = Math.min(maxWindowHeight(bounds.h), id === PRS_ID ? PRS_WINDOW_MAX_H : bounds.h, bounds.h - win.y);
+      const ch = Math.min(Math.max(MIN_H, h), maxHeight);
+      return { ...prev, [id]: { ...win, w: cw, h: ch } };
+    });
+  }, [bounds.w, bounds.h]);
+
+  const resetWindow = useCallback((id: string) => {
+    setStates((prev) => {
+      const win = prev[id];
+      if (!win) return prev;
+      const defaultGeom = id === TERM_ID
+        ? termGeom(vw, vh, posts)
+        : id === PRS_ID
+          ? prsGeom(vw, vh)
+          : id.startsWith('legal:')
+            ? legalGeom(vw, vh)
+            : id.startsWith('show:')
+              ? showGeom(vw, vh)
+              : null;
+      if (!defaultGeom) return prev;
+      return { ...prev, [id]: { ...win, ...defaultGeom } };
+    });
+  }, [posts, vh, vw]);
+
+  const titleDragProps = useCallback(
+    (id: string) => ({
+      onPointerDown: (e: React.PointerEvent) => {
+        if (e.button !== 0) return;
+        const w = states[id];
+        if (!w) return;
+        focus(id);
+        const startPx = e.clientX;
+        const startPy = e.clientY;
+        const originX = w.x;
+        const originY = w.y;
+        const pointerId = e.pointerId;
+        const onMove = (ev: PointerEvent) => {
+          if (ev.pointerId !== pointerId) return;
+          move(id, originX + (ev.clientX - startPx), originY + (ev.clientY - startPy));
+        };
+        const onUp = (ev: PointerEvent) => {
+          if (ev.pointerId !== pointerId) return;
+          globalThis.removeEventListener('pointermove', onMove);
+          globalThis.removeEventListener('pointerup', onUp);
+        };
+        globalThis.addEventListener('pointermove', onMove);
+        globalThis.addEventListener('pointerup', onUp);
+      },
+    }),
+    [states, focus, move],
+  );
+
+  const resizeHandleProps = useCallback(
+    (id: string) => ({
+      onPointerDown: (e: React.PointerEvent) => {
+        if (e.button !== 0) return;
+        const w = states[id];
+        if (!w) return;
+        focus(id);
+        const startPx = e.clientX;
+        const startPy = e.clientY;
+        const startW = w.w;
+        const startH = w.h;
+        const pointerId = e.pointerId;
+        const onMove = (ev: PointerEvent) => {
+          if (ev.pointerId !== pointerId) return;
+          resize(id, startW + (ev.clientX - startPx), startH + (ev.clientY - startPy));
+        };
+        const onUp = (ev: PointerEvent) => {
+          if (ev.pointerId !== pointerId) return;
+          globalThis.removeEventListener('pointermove', onMove);
+          globalThis.removeEventListener('pointerup', onUp);
+        };
+        globalThis.addEventListener('pointermove', onMove);
+        globalThis.addEventListener('pointerup', onUp);
+      },
+    }),
+    [states, focus, resize],
+  );
+
+  const postByIndex = useCallback((i: number) => posts[i], [posts]);
+  const postById = (slug: string) => posts.find((p) => p.slug === slug);
+  const postSlugs = useMemo(() => new Set(posts.map((post) => post.slug)), [posts]);
+  const currentPost = postByIndex(cursor);
+
+  const loadMdx = useCallback((slug: string) => {
+    if (!postSlugs.has(slug) || mdxBySlug[slug] || loadingSlugs.current.has(slug)) return;
+
+    loadingSlugs.current.add(slug);
+    void fetch(`/api/blog-mdx/${encodeURIComponent(slug)}`)
+      .then((response) => {
+        if (!response.ok) throw new Error(`Failed to load ${slug}`);
+        return response.json() as Promise<{ mdxSource: MDXRemoteSerializeResult }>;
+      })
+      .then(({ mdxSource }) => {
+        setMdxBySlug((prev) => ({ ...prev, [slug]: { status: 'ready', source: mdxSource } }));
+      })
+      .catch(() => {
+        setMdxBySlug((prev) => ({ ...prev, [slug]: { status: 'error' } }));
+      })
+      .finally(() => {
+        loadingSlugs.current.delete(slug);
+      });
+  }, [mdxBySlug, postSlugs]);
+
+  useEffect(() => {
+    const slugs = Object.keys(states)
+      .filter((id) => id.startsWith('show:'))
+      .map((id) => id.slice('show:'.length));
+
+    for (const slug of slugs) {
+      loadMdx(slug);
+    }
+  }, [loadMdx, states]);
+
+  useEffect(() => {
+    if (currentPost) loadMdx(currentPost.slug);
+  }, [currentPost, loadMdx]);
+
+  const openAt = (i: number) => {
+    const post = postByIndex(i);
+    if (!post) return;
+    loadMdx(post.slug);
+    open(showWinId(post.slug), showGeom(vw, vh));
+    setCursor(i);
+    updatePostUrl(post.slug);
+  };
+
+  const openBlogSlug = useCallback((slug: string) => {
+    const index = posts.findIndex((post) => post.slug === slug);
+    if (index === -1) return false;
+    loadMdx(slug);
+    open(showWinId(slug), showGeom(vw, vh));
+    setCursor(index);
+    updatePostUrl(slug);
+    return true;
+  }, [loadMdx, open, posts, vh, vw]);
+
+  const openPrs = useCallback(() => {
+    open(PRS_ID, prsGeom(vw, vh));
+  }, [open, vh, vw]);
+
+  const openLegal = useCallback((variant: LegalWindowVariant) => {
+    open(legalWinId(variant), legalGeom(vw, vh));
+  }, [open, vh, vw]);
+
+  const onShellClickCapture = (e: React.MouseEvent<HTMLDivElement>) => {
+    if (e.defaultPrevented || e.button !== 0 || e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) return;
+    const anchor = (e.target as Element | null)?.closest<HTMLAnchorElement>('a[href]');
+    if (!anchor) return;
+
+    const url = new URL(anchor.href, globalThis.location.href);
+    if (url.origin !== globalThis.location.origin) return;
+    const match = /^\/blog\/([^/]+)$/.exec(url.pathname);
+    if (!match) return;
+
+    if (openBlogSlug(decodeURIComponent(match[1]))) {
+      e.preventDefault();
+    }
+  };
+
+  const currentBranch = currentPost ? branchOf(currentPost) : undefined;
+
+  const windows: OpenWin[] = useMemo(() => {
+    const top = maxZof(states);
+    return Object.values(states)
+      .toSorted((a, b) => a.z - b.z)
+      .map((w) => {
+        const clamped = clampWinToViewport(w, vw, vh);
+        return {
+          id: clamped.id,
+          geom: { x: clamped.x, y: clamped.y, w: clamped.w, h: clamped.h },
+          z: clamped.z,
+          focused: clamped.z === top,
+        };
+      });
+  }, [states, vw, vh]);
+
+  useEffect(() => {
+    if (windows.find((win) => win.focused)?.id !== TERM_ID) return;
+    const term = document.querySelector<HTMLElement>(`[data-retro-window-id="${TERM_ID}"]`);
+    term?.focus({ preventScroll: true });
+  }, [windows]);
+
+  const onLogKeyDown = (e: React.KeyboardEvent) => {
+    if (windows.find((win) => win.focused)?.id !== TERM_ID) return;
+    switch (e.key) {
+      case 'ArrowDown': {
+        e.preventDefault();
+        setCursor((current) => Math.min(posts.length - 1, current + 1));
+        break;
+      }
+      case 'ArrowUp': {
+        e.preventDefault();
+        setCursor((current) => Math.max(0, current - 1));
+        break;
+      }
+      case 'Enter': {
+        e.preventDefault();
+        openAt(cursor);
+        break;
+      }
+      default: {
+        break;
+      }
+    }
+  };
+
+  return (
+    <div className="retro-terminal-shell" onClickCapture={onShellClickCapture}>
+      <div className="retro-terminal-desktop">
+        <div className="retro-terminal-crt" aria-hidden="true" />
+        <DesktopProfile onOpenPrs={openPrs} />
+        <DesktopFooter onOpenLegal={openLegal} />
+
+        {states[TERM_ID] ? null : (
+          <button
+            type="button"
+            className="retro-terminal-launcher"
+            onClick={() => open(TERM_ID, termGeom(vw, vh, posts))}
+            aria-label="Open blog archive terminal"
+          >
+            <span className="retro-terminal-launcher-glyph" aria-hidden="true">
+              <svg
+                viewBox="0 0 24 24"
+                width="30"
+                height="30"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              >
+                <rect x="2" y="4" width="20" height="14" rx="2" />
+                <path d="m6 9 3 3-3 3" />
+                <path d="M13 15h4" />
+              </svg>
+            </span>
+            <span className="retro-terminal-launcher-label">archive agent</span>
+          </button>
+        )}
+
+        {windows.map((win) => {
+          const active = win.focused;
+          if (win.id === TERM_ID) {
+            return (
+              <TermWindow
+                key={win.id}
+                win={win}
+                active={active}
+                title="ssh blog@charpeni.com 'archive agent'"
+                onClose={() => close(win.id)}
+                onEscape={() => close(win.id)}
+                dragProps={titleDragProps(win.id)}
+                resizeProps={resizeHandleProps(win.id)}
+                onActivate={() => focus(win.id)}
+                onKeyDown={onLogKeyDown}
+                onTitleDoubleClick={() => resetWindow(win.id)}
+              >
+                <GraphLog
+                  posts={posts}
+                  cursor={cursor}
+                  onSelect={setCursor}
+                  onOpen={openAt}
+                  contentRef={contentRef}
+                />
+                <div className="retro-terminal-status">
+                  <span>
+                    <b>{posts.length}</b> commits · branch{' '}
+                    <b>{currentBranch ?? 'main'}</b> · cursor{' '}
+                    <b>{String(cursor + 1).padStart(2, '0')}</b>/{posts.length}
+                  </span>
+                  <span className="retro-terminal-status-hint">
+                    ↑/↓ move · enter show · dbl-click open · drag ◢ to resize
+                  </span>
+                </div>
+              </TermWindow>
+            );
+          }
+          if (win.id.startsWith('show:')) {
+            const slug = win.id.slice('show:'.length);
+            const post = postById(slug);
+            if (!post) return null;
+            return (
+              <ShowTermWindow
+                key={win.id}
+                win={win}
+                active={active}
+                post={post}
+                mdxState={mdxBySlug[slug]}
+                onClose={() => closeShow(win.id)}
+                onActivate={() => focus(win.id)}
+                dragProps={titleDragProps(win.id)}
+                resizeProps={resizeHandleProps(win.id)}
+                onOpenBlogLink={openBlogSlug}
+                onTitleDoubleClick={() => resetWindow(win.id)}
+              />
+            );
+          }
+          if (win.id === PRS_ID) {
+            return (
+              <LatestPrsWindow
+                key={win.id}
+                win={win}
+                active={active}
+                onClose={() => close(win.id)}
+                onActivate={() => focus(win.id)}
+                dragProps={titleDragProps(win.id)}
+                resizeProps={resizeHandleProps(win.id)}
+                onTitleDoubleClick={() => resetWindow(win.id)}
+              />
+            );
+          }
+          if (win.id.startsWith('legal:')) {
+            const variant = win.id.slice('legal:'.length) as LegalWindowVariant;
+            if (variant !== 'disclaimer' && variant !== 'privacy-policy') return null;
+            return (
+              <LegalWindow
+                key={win.id}
+                win={win}
+                active={active}
+                variant={variant}
+                onOpenLegal={openLegal}
+                onClose={() => close(win.id)}
+                onActivate={() => focus(win.id)}
+                dragProps={titleDragProps(win.id)}
+                resizeProps={resizeHandleProps(win.id)}
+                onTitleDoubleClick={() => resetWindow(win.id)}
+              />
+            );
+          }
+          return null;
+        })}
+
+        {/* exit button — top-right corner, fits the cream theme */}
+        <button
+          className="retro-toggle retro-toggle--retro"
+          onClick={() => {
+            // Exit back to the route that entered retro mode. Internal terminal
+            // navigation uses history.replaceState, so reload after restoring it
+            // to make Next render the page that matches the intended URL.
+            setRetro(false);
+            globalThis.history.replaceState(globalThis.history.state, '', entryPath.current);
+            globalThis.location.reload();
+          }}
+          style={{ position: 'absolute', top: 12, right: 12, zIndex: 99_999, height: 32 }}
+          aria-label="Exit terminal mode"
+        >
+          <span className="retro-toggle-dot" />
+          EXIT TERMINAL
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/components/retro-terminal/DesktopChrome.tsx
+++ b/components/retro-terminal/DesktopChrome.tsx
@@ -1,0 +1,90 @@
+import Image from 'next/image';
+
+import type { LegalWindowVariant } from './types';
+
+export function DesktopProfile({ onOpenPrs }: { onOpenPrs: () => void }) {
+  return (
+    <>
+      <div className="retro-terminal-profile-icon" aria-label="Selected desktop item: profile.txt" aria-selected="true">
+        <div className="retro-terminal-profile-icon-glyph" aria-hidden="true">
+          <Image
+            src="/static/images/nicolas_charpentier.jpeg"
+            alt=""
+            width={58}
+            height={58}
+            sizes="58px"
+            className="retro-terminal-profile-icon-img"
+          />
+        </div>
+        <div className="retro-terminal-profile-icon-label">profile.txt</div>
+      </div>
+      <aside className="retro-terminal-profile" aria-label="About Nicolas Charpentier">
+        <div className="retro-terminal-profile-name">
+          Nicolas Charpentier{' '}
+          <a className="retro-terminal-profile-email" href="mailto:blog@nicolascharpentier.com">
+            &lt;blog@nicolascharpentier.com&gt;
+          </a>
+        </div>
+        <div className="retro-terminal-profile-role">
+          Staff Software Engineer — frontend infrastructure &amp; developer tooling
+        </div>
+        <div className="retro-terminal-profile-stack">
+          TypeScript · React Native · React · GraphQL · CI/CD
+        </div>
+        <div className="retro-terminal-profile-current">
+          Currently @{' '}
+          <a href="https://shortcut.com" target="_blank" rel="noopener noreferrer">Shortcut</a>
+          {' — '}
+          <a href="https://korey.ai" target="_blank" rel="noopener noreferrer">Korey.ai</a>
+          {' · open source enthusiast'}
+        </div>
+        <div className="retro-terminal-profile-links">
+          <a href="https://github.com/charpeni" target="_blank" rel="noopener noreferrer">github.com/charpeni</a>
+          {' · '}
+          <a href="https://www.linkedin.com/in/nicolas-charpentier-8a2b8a104/" target="_blank" rel="noopener noreferrer">linkedin.com/in/nicolas-charpentier-8a2b8a104</a>
+          {' · '}
+          <a href="https://x.com/charpeni_" target="_blank" rel="noopener noreferrer">x.com/charpeni_</a>
+          {' · '}
+          <a href="https://bsky.app/profile/charpeni.bsky.social" target="_blank" rel="noopener noreferrer">bsky.app/charpeni.bsky.social</a>
+          {' · '}
+          <a href="/blog/rss.xml" target="_blank" rel="noopener noreferrer">rss</a>
+          {' · '}
+          <a
+            href="https://prs.charpeni.com"
+            onClick={(e) => {
+              e.preventDefault();
+              onOpenPrs();
+            }}
+          >latest PRs</a>
+        </div>
+      </aside>
+    </>
+  );
+}
+
+export function DesktopFooter({ onOpenLegal }: { onOpenLegal: (variant: LegalWindowVariant) => void }) {
+  return (
+    <footer className="retro-terminal-footer">
+      <div className="retro-terminal-footer-links">
+        <button
+          type="button"
+          onClick={(e) => {
+            e.preventDefault();
+            onOpenLegal('disclaimer');
+          }}
+        >Disclaimer</button>
+        <span aria-hidden="true">|</span>
+        <button
+          type="button"
+          onClick={(e) => {
+            e.preventDefault();
+            onOpenLegal('privacy-policy');
+          }}
+        >Privacy Policy</button>
+        <span aria-hidden="true">|</span>
+        <a href="/blog/rss.xml" target="_blank" rel="noopener noreferrer">RSS Feed</a>
+      </div>
+      <div>© 2021-present Nicolas Charpentier. All Rights Reserved.</div>
+    </footer>
+  );
+}

--- a/components/retro-terminal/GraphLog.tsx
+++ b/components/retro-terminal/GraphLog.tsx
@@ -80,12 +80,14 @@ export function GraphLog({
   cursor,
   onSelect,
   onOpen,
+  isMobile,
   contentRef,
 }: {
   posts: PostFrontMatter[];
   cursor: number;
   onSelect: (i: number) => void;
   onOpen: (i: number) => void;
+  isMobile: boolean;
   contentRef: React.RefObject<HTMLDivElement | null>;
 }) {
   const graph = useMemo(() => computeGraph(posts, posts), [posts]);
@@ -159,10 +161,10 @@ export function GraphLog({
                       rowRefs.current[i] = el;
                     }}
                     className={`retro-terminal-row ${isSel ? 'retro-terminal-row--selected' : ''}`}
-                    onClick={() => onSelect(i)}
+                    onClick={() => (isMobile ? onOpen(i) : onSelect(i))}
                     onDoubleClick={() => onOpen(i)}
                   >
-                    <GraphRail row={row} activeBranches={activeBranches} />
+                    {isMobile ? null : <GraphRail row={row} activeBranches={activeBranches} />}
                     <span className="retro-terminal-hash">{hash}</span>
                     <span className="retro-terminal-date">{formatYearMonth(post.publishedAt)}</span>
                     {branch ? (

--- a/components/retro-terminal/GraphLog.tsx
+++ b/components/retro-terminal/GraphLog.tsx
@@ -4,7 +4,7 @@ import { BRANCH_TAGS, computeGraph, shortHash } from '@/utils/graph';
 import type { BranchTag, RowGraph } from '@/utils/graph';
 import type { PostFrontMatter } from '@/utils/mdx';
 
-import { formatYearMonth } from './format';
+import { formatIsoDate } from './format';
 import { GRAPH_LANE_GAP, GRAPH_MAIN_X, GRAPH_ROW_H, graphWidth } from './geometry';
 import { BRANCH_COLORS, branchOf } from './postUtils';
 
@@ -166,7 +166,7 @@ export function GraphLog({
                   >
                     {isMobile ? null : <GraphRail row={row} activeBranches={activeBranches} />}
                     <span className="retro-terminal-hash">{hash}</span>
-                    <span className="retro-terminal-date">{formatYearMonth(post.publishedAt)}</span>
+                    <span className="retro-terminal-date">{formatIsoDate(post.publishedAt)}</span>
                     {branch ? (
                       <span
                         className="retro-terminal-refs"

--- a/components/retro-terminal/GraphLog.tsx
+++ b/components/retro-terminal/GraphLog.tsx
@@ -1,0 +1,197 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+
+import { BRANCH_TAGS, computeGraph, shortHash } from '@/utils/graph';
+import type { BranchTag, RowGraph } from '@/utils/graph';
+import type { PostFrontMatter } from '@/utils/mdx';
+
+import { formatYearMonth } from './format';
+import { GRAPH_LANE_GAP, GRAPH_MAIN_X, GRAPH_ROW_H, graphWidth } from './geometry';
+import { BRANCH_COLORS, branchOf } from './postUtils';
+
+function GraphRail({
+  row,
+  activeBranches,
+}: {
+  row: RowGraph;
+  activeBranches: BranchTag[];
+}) {
+  const height = GRAPH_ROW_H;
+  const mid = height / 2;
+  const mainColor = '#7a7160';
+  const width = graphWidth(activeBranches.length);
+  const laneX = (i: number) => GRAPH_MAIN_X + GRAPH_LANE_GAP * (i + 1);
+
+  return (
+    <svg
+      className="retro-terminal-graph"
+      width={width}
+      height={height}
+      viewBox={`0 0 ${width} ${height}`}
+      aria-hidden="true"
+      focusable="false"
+    >
+      {row.mainTopLine ? (
+        <line className="retro-terminal-graph-line" x1={GRAPH_MAIN_X} y1={0} x2={GRAPH_MAIN_X} y2={mid} stroke={mainColor} />
+      ) : null}
+      {row.mainBottomLine ? (
+        <line className="retro-terminal-graph-line" x1={GRAPH_MAIN_X} y1={mid} x2={GRAPH_MAIN_X} y2={height} stroke={mainColor} />
+      ) : null}
+      {row.mainOrb ? (
+        <circle className="retro-terminal-graph-orb retro-terminal-graph-orb--main" cx={GRAPH_MAIN_X} cy={mid} r={4} />
+      ) : null}
+      {activeBranches.map((branch, i) => {
+        const cell = row.lanes[i];
+        const x = laneX(i);
+        const color = BRANCH_COLORS[branch] ?? '#b45309';
+        return (
+          <g key={branch}>
+            {cell.topLine ? (
+              <line className="retro-terminal-graph-line" x1={x} y1={0} x2={x} y2={mid} stroke={color} />
+            ) : null}
+            {cell.bottomLine ? (
+              <line className="retro-terminal-graph-line" x1={x} y1={mid} x2={x} y2={height} stroke={color} />
+            ) : null}
+            {cell.topSprout ? (
+              <path
+                className="retro-terminal-graph-line"
+                d={`M ${GRAPH_MAIN_X} ${mid} C ${GRAPH_MAIN_X + 6} ${mid - 1}, ${x - 8} 1, ${x} 0`}
+                stroke={color}
+              />
+            ) : null}
+            {cell.topMerge ? (
+              <path
+                className="retro-terminal-graph-line"
+                d={`M ${x} ${mid} C ${x - 8} ${mid - 1}, ${GRAPH_MAIN_X + 6} 1, ${GRAPH_MAIN_X} 0`}
+                stroke={color}
+              />
+            ) : null}
+            {cell.laneOrb ? (
+              <circle className="retro-terminal-graph-orb" cx={x} cy={mid} r={4} fill={color} />
+            ) : null}
+          </g>
+        );
+      })}
+    </svg>
+  );
+}
+
+export function GraphLog({
+  posts,
+  cursor,
+  onSelect,
+  onOpen,
+  contentRef,
+}: {
+  posts: PostFrontMatter[];
+  cursor: number;
+  onSelect: (i: number) => void;
+  onOpen: (i: number) => void;
+  contentRef: React.RefObject<HTMLDivElement | null>;
+}) {
+  const graph = useMemo(() => computeGraph(posts, posts), [posts]);
+  const { activeBranches, rows } = graph;
+  const rowRefs = useRef<(HTMLDivElement | null)[]>([]);
+  const [agentPhase, setAgentPhase] = useState<'thinking' | 'indexing' | 'tool' | 'done'>('thinking');
+
+  useEffect(() => {
+    const el = rowRefs.current[cursor];
+    if (el) el.scrollIntoView({ block: 'nearest' });
+  }, [cursor]);
+
+  useEffect(() => {
+    const indexingTimer = globalThis.setTimeout(() => setAgentPhase('indexing'), 900);
+    const toolTimer = globalThis.setTimeout(() => setAgentPhase('tool'), 2100);
+    const doneTimer = globalThis.setTimeout(() => setAgentPhase('done'), 3800);
+    return () => {
+      globalThis.clearTimeout(indexingTimer);
+      globalThis.clearTimeout(toolTimer);
+      globalThis.clearTimeout(doneTimer);
+    };
+  }, []);
+
+  return (
+    <>
+      <div className="retro-terminal-agent">
+        <div className="retro-terminal-agent-user">
+          <span className="retro-terminal-agent-mark">›</span>
+          <span>List charpeni.com blog posts</span>
+        </div>
+        <div className="retro-terminal-agent-step">
+          <span className="retro-terminal-agent-orb" aria-hidden="true" />
+          <span>
+            {agentPhase === 'thinking'
+              ? 'Reading archive intent and route context'
+              : agentPhase === 'indexing'
+                ? 'Indexing posts, dates, and branch tags'
+                : 'Archive mapped to commit log'}
+          </span>
+          {agentPhase === 'thinking' || agentPhase === 'indexing' ? <span className="retro-terminal-agent-dots" aria-hidden="true" /> : null}
+        </div>
+        <div className={`retro-terminal-agent-tool ${agentPhase === 'thinking' || agentPhase === 'indexing' ? 'retro-terminal-agent-tool--pending' : ''}`}>
+          <div className="retro-terminal-agent-tool-name">tool: archive.list_posts --format=git-log</div>
+          <div className="retro-terminal-prompt-cmd">
+            {agentPhase === 'thinking' || agentPhase === 'indexing' ? 'queued' : '$ git log --graph --oneline --all --date=short'}
+            {agentPhase === 'tool' ? <span className="retro-terminal-agent-dots" aria-hidden="true" /> : null}
+          </div>
+        </div>
+      </div>
+      {agentPhase === 'done' ? (
+        <>
+          <div className="retro-terminal-prompt-meta">
+            connected to charpeni.com · {posts.length} commits · {BRANCH_TAGS.length} branches · HEAD at{' '}
+            {posts[0] ? shortHash(posts[0].slug) : '—'}
+          </div>
+          <div
+            ref={contentRef}
+            className="retro-terminal-content"
+            tabIndex={0}
+          >
+            <div className="retro-terminal-log">
+              {posts.map((post, i) => {
+                const row = rows[i];
+                const hash = shortHash(post.slug);
+                const branch = branchOf(post);
+                const isSel = i === cursor;
+                return (
+                  <div
+                    key={post.slug}
+                    ref={(el) => {
+                      rowRefs.current[i] = el;
+                    }}
+                    className={`retro-terminal-row ${isSel ? 'retro-terminal-row--selected' : ''}`}
+                    onClick={() => onSelect(i)}
+                    onDoubleClick={() => onOpen(i)}
+                  >
+                    <GraphRail row={row} activeBranches={activeBranches} />
+                    <span className="retro-terminal-hash">{hash}</span>
+                    <span className="retro-terminal-date">{formatYearMonth(post.publishedAt)}</span>
+                    {branch ? (
+                      <span
+                        className="retro-terminal-refs"
+                        style={{ color: BRANCH_COLORS[branch] ?? '#b45309' }}
+                      >
+                        ({branch})
+                      </span>
+                    ) : null}
+                    <span className="retro-terminal-msg">{post.title}</span>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        </>
+      ) : (
+        <div className="retro-terminal-content retro-terminal-content--loading" ref={contentRef} tabIndex={0}>
+          <span className="retro-terminal-loading-line">
+            {agentPhase === 'thinking'
+              ? 'Planning archive query'
+              : agentPhase === 'indexing'
+                ? 'Preparing graph lanes'
+                : 'Running archive.list_posts'}
+            <span className="retro-terminal-agent-dots" aria-hidden="true" />
+          </span>
+        </div>
+      )}
+    </>
+  );
+}

--- a/components/retro-terminal/LatestPrsWindow.tsx
+++ b/components/retro-terminal/LatestPrsWindow.tsx
@@ -1,0 +1,92 @@
+import { useEffect, useState } from 'react';
+
+import { formatYearMonth } from './format';
+import { TermWindow } from './TermWindow';
+
+import type { LatestPr, LatestPrsState, OpenWin } from './types';
+
+export function LatestPrsWindow({
+  win,
+  active,
+  onClose,
+  onActivate,
+  dragProps,
+  resizeProps,
+  onTitleDoubleClick,
+}: {
+  win: OpenWin;
+  active: boolean;
+  onClose: () => void;
+  onActivate: () => void;
+  dragProps: { onPointerDown: (e: React.PointerEvent) => void };
+  resizeProps: { onPointerDown: (e: React.PointerEvent) => void };
+  onTitleDoubleClick?: () => void;
+}) {
+  const [state, setState] = useState<LatestPrsState>({ status: 'loading' });
+
+  useEffect(() => {
+    let cancelled = false;
+    void fetch('/api/latestPrs')
+      .then((response) => {
+        if (!response.ok) throw new Error('Failed to load latest PRs');
+        return response.json() as Promise<{ prs: LatestPr[] }>;
+      })
+      .then(({ prs }) => {
+        if (!cancelled) setState({ status: 'ready', prs });
+      })
+      .catch(() => {
+        if (!cancelled) setState({ status: 'error' });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return (
+    <TermWindow
+      win={win}
+      active={active}
+      title="open https://prs.charpeni.com"
+      onClose={onClose}
+      onEscape={onClose}
+      dragProps={dragProps}
+      resizeProps={resizeProps}
+      onActivate={onActivate}
+      onTitleDoubleClick={onTitleDoubleClick}
+    >
+      <div className="retro-terminal-prs-window">
+        <div className="retro-terminal-prs-toolbar">
+          <span>latest open source contributions</span>
+          <a href="https://prs.charpeni.com" target="_blank" rel="noopener noreferrer">
+            Open latest PRs ↗
+          </a>
+        </div>
+        <div className="retro-terminal-prs-list">
+          {state.status === 'loading' ? (
+            <div className="retro-terminal-prs-message">Fetching recent pull requests...</div>
+          ) : null}
+          {state.status === 'error' ? (
+            <div className="retro-terminal-prs-message">
+              Could not load the feed. Use the external link above.
+            </div>
+          ) : null}
+          {state.status === 'ready' ? state.prs.map((pr) => (
+            <a
+              key={pr.url}
+              className="retro-terminal-prs-row"
+              href={pr.url}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              <span className="retro-terminal-prs-number">{pr.number}</span>
+              <span className="retro-terminal-prs-copy">
+                <span className="retro-terminal-prs-title">{pr.title}</span>
+                <span className="retro-terminal-prs-repo">{pr.repo} · {formatYearMonth(pr.publishedAt)}</span>
+              </span>
+            </a>
+          )) : null}
+        </div>
+      </div>
+    </TermWindow>
+  );
+}

--- a/components/retro-terminal/LatestPrsWindow.tsx
+++ b/components/retro-terminal/LatestPrsWindow.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 
-import { formatYearMonth } from './format';
+import { formatIsoDate } from './format';
 import { TermWindow } from './TermWindow';
 
 import type { LatestPr, LatestPrsState, OpenWin } from './types';
@@ -13,6 +13,7 @@ export function LatestPrsWindow({
   dragProps,
   resizeProps,
   onTitleDoubleClick,
+  compact,
 }: {
   win: OpenWin;
   active: boolean;
@@ -21,6 +22,7 @@ export function LatestPrsWindow({
   dragProps: { onPointerDown: (e: React.PointerEvent) => void };
   resizeProps: { onPointerDown: (e: React.PointerEvent) => void };
   onTitleDoubleClick?: () => void;
+  compact?: boolean;
 }) {
   const [state, setState] = useState<LatestPrsState>({ status: 'loading' });
 
@@ -53,6 +55,7 @@ export function LatestPrsWindow({
       resizeProps={resizeProps}
       onActivate={onActivate}
       onTitleDoubleClick={onTitleDoubleClick}
+      compact={compact}
     >
       <div className="retro-terminal-prs-window">
         <div className="retro-terminal-prs-toolbar">
@@ -81,7 +84,7 @@ export function LatestPrsWindow({
               <span className="retro-terminal-prs-number">{pr.number}</span>
               <span className="retro-terminal-prs-copy">
                 <span className="retro-terminal-prs-title">{pr.title}</span>
-                <span className="retro-terminal-prs-repo">{pr.repo} · {formatYearMonth(pr.publishedAt)}</span>
+                <span className="retro-terminal-prs-repo">{pr.repo} · {formatIsoDate(pr.publishedAt)}</span>
               </span>
             </a>
           )) : null}

--- a/components/retro-terminal/LegalWindow.tsx
+++ b/components/retro-terminal/LegalWindow.tsx
@@ -1,0 +1,69 @@
+import { LegalContent, LEGAL_TITLES } from '@/components/LegalContent';
+
+import { TermWindow } from './TermWindow';
+
+import type { LegalWindowVariant, OpenWin } from './types';
+
+export function LegalWindow({
+  win,
+  active,
+  variant,
+  onOpenLegal,
+  onClose,
+  onActivate,
+  dragProps,
+  resizeProps,
+  onTitleDoubleClick,
+}: {
+  win: OpenWin;
+  active: boolean;
+  variant: LegalWindowVariant;
+  onOpenLegal: (variant: LegalWindowVariant) => void;
+  onClose: () => void;
+  onActivate: () => void;
+  dragProps: { onPointerDown: (e: React.PointerEvent) => void };
+  resizeProps: { onPointerDown: (e: React.PointerEvent) => void };
+  onTitleDoubleClick?: () => void;
+}) {
+  const onContentClick = (e: React.MouseEvent<HTMLDivElement>) => {
+    if (e.defaultPrevented || e.button !== 0 || e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) return;
+    const anchor = (e.target as Element | null)?.closest<HTMLAnchorElement>('a[href]');
+    if (!anchor) return;
+
+    const url = new URL(anchor.href, globalThis.location.href);
+    if (url.origin !== globalThis.location.origin) return;
+    if (url.pathname === '/disclaimer') {
+      e.preventDefault();
+      onOpenLegal('disclaimer');
+    }
+    if (url.pathname === '/privacy-policy') {
+      e.preventDefault();
+      onOpenLegal('privacy-policy');
+    }
+  };
+
+  return (
+    <TermWindow
+      win={win}
+      active={active}
+      title={`less /site/${variant}.txt`}
+      onClose={onClose}
+      onEscape={onClose}
+      dragProps={dragProps}
+      resizeProps={resizeProps}
+      onActivate={onActivate}
+      onTitleDoubleClick={onTitleDoubleClick}
+    >
+      <div className="retro-terminal-legal-window" onClickCapture={onContentClick}>
+        <div className="retro-terminal-legal-title">{LEGAL_TITLES[variant]}</div>
+        <div className="retro-terminal-legal-content">
+          <LegalContent variant={variant} />
+        </div>
+      </div>
+      <div className="retro-terminal-status">
+        <span><b>{variant}</b></span>
+        <span className="retro-terminal-status-hint">esc close · drag ◢ to resize</span>
+      </div>
+    </TermWindow>
+  );
+}

--- a/components/retro-terminal/LegalWindow.tsx
+++ b/components/retro-terminal/LegalWindow.tsx
@@ -14,6 +14,7 @@ export function LegalWindow({
   dragProps,
   resizeProps,
   onTitleDoubleClick,
+  compact,
 }: {
   win: OpenWin;
   active: boolean;
@@ -24,6 +25,7 @@ export function LegalWindow({
   dragProps: { onPointerDown: (e: React.PointerEvent) => void };
   resizeProps: { onPointerDown: (e: React.PointerEvent) => void };
   onTitleDoubleClick?: () => void;
+  compact?: boolean;
 }) {
   const onContentClick = (e: React.MouseEvent<HTMLDivElement>) => {
     if (e.defaultPrevented || e.button !== 0 || e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) return;
@@ -53,6 +55,7 @@ export function LegalWindow({
       resizeProps={resizeProps}
       onActivate={onActivate}
       onTitleDoubleClick={onTitleDoubleClick}
+      compact={compact}
     >
       <div className="retro-terminal-legal-window" onClickCapture={onContentClick}>
         <div className="retro-terminal-legal-title">{LEGAL_TITLES[variant]}</div>

--- a/components/retro-terminal/ShowWindow.tsx
+++ b/components/retro-terminal/ShowWindow.tsx
@@ -1,0 +1,212 @@
+import Image, { type ImageProps } from 'next/image';
+import { type CSSProperties } from 'react';
+
+import { MDXRemote } from 'next-mdx-remote';
+
+import { Comments } from '@/components/Comments';
+import MDXComponents from '@/components/MDXComponents';
+import { shortHash } from '@/utils/graph';
+import type { PostFrontMatter } from '@/utils/mdx';
+
+import { useCopyMarkdown } from './clipboard';
+import { formatLongDate } from './format';
+import { branchOf, isBranch } from './postUtils';
+import { TermWindow } from './TermWindow';
+
+import type { MdxState, OpenWin } from './types';
+
+function dimension(value: ImageProps['width']): number | null {
+  if (typeof value === 'number') return value;
+  if (typeof value !== 'string') return null;
+  const parsed = Number.parseFloat(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function TerminalImage({ alt, width, height, style, ...props }: ImageProps) {
+  const w = dimension(width);
+  const h = dimension(height);
+
+  if (!w || !h) {
+    return <Image alt={alt} width={width} height={height} style={style} {...props} />;
+  }
+
+  const frameStyle: CSSProperties = {
+    alignSelf: style?.alignSelf,
+    aspectRatio: `${w} / ${h}`,
+    width: `min(100%, ${w}px)`,
+  };
+
+  return (
+    <span className="retro-terminal-image-frame" style={frameStyle}>
+      <Image
+        alt={alt}
+        width={width}
+        height={height}
+        style={{ ...style, width: '100%', height: 'auto' }}
+        {...props}
+      />
+    </span>
+  );
+}
+
+const TERMINAL_MDX_COMPONENTS = {
+  ...MDXComponents,
+  Image: TerminalImage,
+};
+
+function ShowBody({
+  post,
+  mdxState,
+  onOpenBlogLink,
+}: {
+  post: PostFrontMatter;
+  mdxState?: MdxState;
+  onOpenBlogLink: (slug: string) => boolean;
+}) {
+  const hash = shortHash(post.slug);
+  const branch = branchOf(post);
+  const date = formatLongDate(post.publishedAt);
+  const otherTags = post.tags.filter((t) => !isBranch(t));
+
+  const onContentClick = (e: React.MouseEvent<HTMLDivElement>) => {
+    if (e.defaultPrevented || e.button !== 0 || e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) return;
+    const anchor = (e.target as Element | null)?.closest<HTMLAnchorElement>('a[href]');
+    if (!anchor) return;
+
+    const url = new URL(anchor.href, globalThis.location.href);
+    if (url.origin !== globalThis.location.origin) return;
+    const match = /^\/blog\/([^/]+)$/.exec(url.pathname);
+    if (!match) return;
+
+    if (onOpenBlogLink(decodeURIComponent(match[1]))) {
+      e.preventDefault();
+    }
+  };
+
+  return (
+    <div className="retro-terminal-show-scroll" onClickCapture={onContentClick}>
+      <div className="retro-terminal-show-meta">
+        commit {hash}
+        {'\n'}Author: Nicolas Charpentier &lt;
+        <a href="mailto:blog@nicolascharpentier.com">blog@nicolascharpentier.com</a>
+        &gt;
+        {'\n'}Date:   {date}
+        {'\n'}Size:   {post.readingTime.text}
+        {branch ? `\nrefs:   refs/heads/${branch}` : ''}
+        {otherTags.length > 0 ? `\ntopic:  ${otherTags.join(', ')}` : ''}
+      </div>
+      <div className="retro-terminal-show-title">{post.title}</div>
+      {post.image ? (
+        <div className="retro-terminal-banner" aria-hidden="true">
+          <Image
+            src={post.image}
+            alt=""
+            aria-hidden="true"
+            fill
+            priority
+            sizes="(max-width: 848px) 100vw, 768px"
+            className="retro-terminal-banner-img"
+          />
+        </div>
+      ) : null}
+      {mdxState?.status === 'ready' ? (
+        <>
+          <div className="prose retro-terminal-prose">
+            <MDXRemote {...mdxState.source} components={TERMINAL_MDX_COMPONENTS} />
+          </div>
+          <div className="retro-terminal-comments">
+            <div className="retro-terminal-comments-title">comments</div>
+            <Comments title={post.title} />
+          </div>
+        </>
+      ) : null}
+      {mdxState ? null : (
+        <div className="retro-terminal-loading-post" aria-busy="true">
+          <div className="retro-terminal-show-meta">loading object from remote archive...</div>
+          <div className="retro-terminal-skeleton-line retro-terminal-skeleton-line--wide" />
+          <div className="retro-terminal-skeleton-line" />
+          <div className="retro-terminal-skeleton-line retro-terminal-skeleton-line--short" />
+          <div className="retro-terminal-skeleton-image" />
+          <div className="retro-terminal-skeleton-line" />
+          <div className="retro-terminal-skeleton-line retro-terminal-skeleton-line--wide" />
+        </div>
+      )}
+      {mdxState?.status === 'error' ? (
+        <div className="retro-terminal-show-meta">error: could not load post body</div>
+      ) : null}
+    </div>
+  );
+}
+
+export function ShowTermWindow({
+  win,
+  active,
+  post,
+  mdxState,
+  onClose,
+  onActivate,
+  dragProps,
+  resizeProps,
+  onOpenBlogLink,
+  onTitleDoubleClick,
+}: {
+  win: OpenWin;
+  active: boolean;
+  post: PostFrontMatter;
+  mdxState?: MdxState;
+  onClose: () => void;
+  onActivate: () => void;
+  dragProps: { onPointerDown: (e: React.PointerEvent) => void };
+  resizeProps: { onPointerDown: (e: React.PointerEvent) => void };
+  onOpenBlogLink: (slug: string) => boolean;
+  onTitleDoubleClick?: () => void;
+}) {
+  const { status: copyStatus, copy } = useCopyMarkdown(post.slug);
+  const branch = branchOf(post);
+
+  const onKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key !== 'c' || e.metaKey || e.ctrlKey || e.altKey || e.shiftKey) return;
+    const t = e.target as HTMLElement | null;
+    if (t && (t.tagName === 'INPUT' || t.tagName === 'TEXTAREA' || t.isContentEditable)) return;
+    e.preventDefault();
+    void copy();
+  };
+
+  const hint =
+    copyStatus === 'copied'
+      ? 'copied to clipboard ✓'
+      : copyStatus === 'error'
+        ? 'copy failed — try again'
+        : copyStatus === 'copying'
+          ? 'copying…'
+          : 'c copy markdown · esc close';
+
+  return (
+    <TermWindow
+      win={win}
+      active={active}
+      title={`git show ${shortHash(post.slug)} — ${post.title}`}
+      onClose={onClose}
+      onEscape={onClose}
+      dragProps={dragProps}
+      resizeProps={resizeProps}
+      onActivate={onActivate}
+      onKeyDown={onKeyDown}
+      onTitleDoubleClick={onTitleDoubleClick}
+    >
+      <ShowBody post={post} mdxState={mdxState} onOpenBlogLink={onOpenBlogLink} />
+      <div className="retro-terminal-status">
+        <span>
+          {branch ? (
+            <>
+              branch <b>refs/heads/{branch}</b>
+            </>
+          ) : (
+            <b>main</b>
+          )}
+        </span>
+        <span className="retro-terminal-status-hint">{hint}</span>
+      </div>
+    </TermWindow>
+  );
+}

--- a/components/retro-terminal/ShowWindow.tsx
+++ b/components/retro-terminal/ShowWindow.tsx
@@ -149,6 +149,7 @@ export function ShowTermWindow({
   resizeProps,
   onOpenBlogLink,
   onTitleDoubleClick,
+  compact,
 }: {
   win: OpenWin;
   active: boolean;
@@ -160,6 +161,7 @@ export function ShowTermWindow({
   resizeProps: { onPointerDown: (e: React.PointerEvent) => void };
   onOpenBlogLink: (slug: string) => boolean;
   onTitleDoubleClick?: () => void;
+  compact?: boolean;
 }) {
   const { status: copyStatus, copy } = useCopyMarkdown(post.slug);
   const branch = branchOf(post);
@@ -193,6 +195,7 @@ export function ShowTermWindow({
       onActivate={onActivate}
       onKeyDown={onKeyDown}
       onTitleDoubleClick={onTitleDoubleClick}
+      compact={compact}
     >
       <ShowBody post={post} mdxState={mdxState} onOpenBlogLink={onOpenBlogLink} />
       <div className="retro-terminal-status">

--- a/components/retro-terminal/TermWindow.tsx
+++ b/components/retro-terminal/TermWindow.tsx
@@ -12,6 +12,8 @@ export function TermWindow({
   onActivate,
   onKeyDown,
   onTitleDoubleClick,
+  windowRef,
+  compact,
 }: {
   win: OpenWin;
   active: boolean;
@@ -24,13 +26,16 @@ export function TermWindow({
   onActivate: () => void;
   onKeyDown?: (e: React.KeyboardEvent) => void;
   onTitleDoubleClick?: () => void;
+  windowRef?: React.Ref<HTMLDivElement>;
+  compact?: boolean;
 }) {
   const { geom } = win;
   return (
     <div
       className={`retro-terminal-window ${active ? 'retro-terminal-window--active' : ''}`}
       data-retro-window-id={win.id}
-      style={{ left: geom.x, top: geom.y, width: geom.w, height: geom.h, zIndex: 100 + win.z }}
+      ref={windowRef}
+      style={compact ? { zIndex: 100 + win.z } : { left: geom.x, top: geom.y, width: geom.w, height: geom.h, zIndex: 100 + win.z }}
       tabIndex={0}
       onKeyDown={(e) => {
         if (e.key === 'Escape') {

--- a/components/retro-terminal/TermWindow.tsx
+++ b/components/retro-terminal/TermWindow.tsx
@@ -1,0 +1,75 @@
+import type { OpenWin } from './types';
+
+export function TermWindow({
+  win,
+  active,
+  title,
+  children,
+  onClose,
+  onEscape,
+  dragProps,
+  resizeProps,
+  onActivate,
+  onKeyDown,
+  onTitleDoubleClick,
+}: {
+  win: OpenWin;
+  active: boolean;
+  title: string;
+  children: React.ReactNode;
+  onClose: () => void;
+  onEscape?: () => void;
+  dragProps: { onPointerDown: (e: React.PointerEvent) => void };
+  resizeProps: { onPointerDown: (e: React.PointerEvent) => void };
+  onActivate: () => void;
+  onKeyDown?: (e: React.KeyboardEvent) => void;
+  onTitleDoubleClick?: () => void;
+}) {
+  const { geom } = win;
+  return (
+    <div
+      className={`retro-terminal-window ${active ? 'retro-terminal-window--active' : ''}`}
+      data-retro-window-id={win.id}
+      style={{ left: geom.x, top: geom.y, width: geom.w, height: geom.h, zIndex: 100 + win.z }}
+      tabIndex={0}
+      onKeyDown={(e) => {
+        if (e.key === 'Escape') {
+          e.preventDefault();
+          (onEscape ?? onClose)();
+          return;
+        }
+        onKeyDown?.(e);
+      }}
+      onPointerDown={(e) => {
+        e.currentTarget.focus({ preventScroll: true });
+        onActivate();
+      }}
+    >
+      <div
+        className={`retro-terminal-titlebar ${active ? 'retro-terminal-titlebar--active' : ''}`}
+        onDoubleClick={(e) => {
+          e.preventDefault();
+          onTitleDoubleClick?.();
+        }}
+        {...dragProps}
+      >
+        <span className="retro-terminal-dots" aria-hidden="true">
+          <span className="retro-terminal-dot" />
+          <span className="retro-terminal-dot" />
+          <span className="retro-terminal-dot" />
+        </span>
+        <span className="retro-terminal-title-text">{title}</span>
+        <button
+          className="retro-terminal-close"
+          aria-label="Close"
+          onClick={onClose}
+          onPointerDown={(e) => e.stopPropagation()}
+        >
+          ×
+        </button>
+      </div>
+      {children}
+      <div className="retro-terminal-resize" {...resizeProps}>◢</div>
+    </div>
+  );
+}

--- a/components/retro-terminal/clipboard.ts
+++ b/components/retro-terminal/clipboard.ts
@@ -1,0 +1,53 @@
+import { useCallback, useState } from 'react';
+
+import type { CopyStatus } from './types';
+
+/**
+ * Writes text to the clipboard, falling back to the legacy
+ * `document.execCommand('copy')` path when the async Clipboard API is absent
+ * or rejected in non-secure local development contexts.
+ */
+async function writeToClipboard(text: string): Promise<void> {
+  try {
+    if (navigator.clipboard?.writeText) {
+      await navigator.clipboard.writeText(text);
+      return;
+    }
+  } catch {
+    // Fall through to the legacy synchronous path below.
+  }
+
+  const ta = document.createElement('textarea');
+  ta.value = text;
+  ta.setAttribute('readonly', '');
+  ta.style.position = 'fixed';
+  ta.style.top = '-1000px';
+  ta.style.opacity = '0';
+  document.body.append(ta);
+  ta.select();
+  const ok = document.execCommand('copy');
+  ta.remove();
+  if (!ok) throw new Error('execCommand copy failed');
+}
+
+/**
+ * Fetches the post's raw Markdown source from `/api/blog/{slug}.md` and writes
+ * it to the clipboard. Exposes an imperative action for the terminal `c` keybind.
+ */
+export function useCopyMarkdown(slug: string) {
+  const [status, setStatus] = useState<CopyStatus>('idle');
+  const copy = useCallback(async () => {
+    setStatus('copying');
+    try {
+      const res = await fetch(`/api/blog/${slug}.md`);
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const md = await res.text();
+      await writeToClipboard(md);
+      setStatus('copied');
+    } catch {
+      setStatus('error');
+    }
+    globalThis.setTimeout(() => setStatus('idle'), 2000);
+  }, [slug]);
+  return { status, copy };
+}

--- a/components/retro-terminal/format.ts
+++ b/components/retro-terminal/format.ts
@@ -1,0 +1,12 @@
+import { format, parseISO } from 'date-fns';
+
+export function formatYearMonth(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso;
+  return d.toISOString().slice(0, 10);
+}
+
+export function formatLongDate(iso: string): string {
+  const d = parseISO(iso);
+  return Number.isNaN(d.getTime()) ? iso : format(d, 'MMMM dd, yyyy');
+}

--- a/components/retro-terminal/format.ts
+++ b/components/retro-terminal/format.ts
@@ -1,6 +1,6 @@
 import { format, parseISO } from 'date-fns';
 
-export function formatYearMonth(iso: string): string {
+export function formatIsoDate(iso: string): string {
   const d = new Date(iso);
   if (Number.isNaN(d.getTime())) return iso;
   return d.toISOString().slice(0, 10);

--- a/components/retro-terminal/geometry.ts
+++ b/components/retro-terminal/geometry.ts
@@ -1,7 +1,7 @@
 import { computeGraph, isBranchTag, shortHash } from '@/utils/graph';
 import type { PostFrontMatter } from '@/utils/mdx';
 
-import { formatYearMonth } from './format';
+import { formatIsoDate } from './format';
 
 import type { WinGeom, WinState } from './types';
 
@@ -26,7 +26,7 @@ function termFitWidth(posts: PostFrontMatter[]): number {
   for (const post of posts) {
     const branch = post.tags.find((t) => isBranchTag(t));
     const refs = branch ? `(${branch}) ` : '';
-    maxChars = Math.max(maxChars, `${shortHash(post.slug)} ${formatYearMonth(post.publishedAt)} ${refs}${post.title}`.length);
+    maxChars = Math.max(maxChars, `${shortHash(post.slug)} ${formatIsoDate(post.publishedAt)} ${refs}${post.title}`.length);
   }
   return Math.ceil(maxChars * ROW_CHAR_W + graphWidth(graph.activeBranches.length) + TERM_CHROME_W);
 }

--- a/components/retro-terminal/geometry.ts
+++ b/components/retro-terminal/geometry.ts
@@ -70,6 +70,9 @@ export function legalGeom(vw: number, vh: number): WinGeom {
 
 export function clampWinToViewport(win: WinState, vw: number, vh: number): WinState {
   const h = Math.min(win.h, maxWindowHeight(vh));
+  if (win.id.startsWith('show:') && vw >= 640 && win.w < 640) {
+    return { ...win, ...showGeom(vw, vh) };
+  }
   const targetW = win.id.startsWith('show:') && win.w >= LEGACY_SHOW_WINDOW_W ? Math.max(win.w, showGeom(vw, vh).w) : win.w;
   const w = Math.max(MIN_W, Math.min(targetW, vw - win.x));
   const x = Math.max(0, Math.min(win.x, vw - Math.min(w, 40)));

--- a/components/retro-terminal/geometry.ts
+++ b/components/retro-terminal/geometry.ts
@@ -1,0 +1,78 @@
+import { computeGraph, isBranchTag, shortHash } from '@/utils/graph';
+import type { PostFrontMatter } from '@/utils/mdx';
+
+import { formatYearMonth } from './format';
+
+import type { WinGeom, WinState } from './types';
+
+export const MIN_W = 240;
+export const MIN_H = 140;
+const MAX_WINDOW_VH = 0.8;
+const LEGACY_SHOW_WINDOW_W = 842;
+export const PRS_WINDOW_MAX_H = 720;
+const ROW_CHAR_W = 7.8;
+const TERM_CHROME_W = 112;
+export const GRAPH_MAIN_X = 7;
+export const GRAPH_LANE_GAP = 18;
+export const GRAPH_ROW_H = 22;
+
+export function graphWidth(laneCount: number): number {
+  return GRAPH_MAIN_X * 2 + laneCount * GRAPH_LANE_GAP;
+}
+
+function termFitWidth(posts: PostFrontMatter[]): number {
+  const graph = computeGraph(posts, posts);
+  let maxChars = 0;
+  for (const post of posts) {
+    const branch = post.tags.find((t) => isBranchTag(t));
+    const refs = branch ? `(${branch}) ` : '';
+    maxChars = Math.max(maxChars, `${shortHash(post.slug)} ${formatYearMonth(post.publishedAt)} ${refs}${post.title}`.length);
+  }
+  return Math.ceil(maxChars * ROW_CHAR_W + graphWidth(graph.activeBranches.length) + TERM_CHROME_W);
+}
+
+export function maxWindowHeight(vh: number): number {
+  return Math.max(1, Math.floor(vh * MAX_WINDOW_VH));
+}
+
+function clampWindowHeight(vh: number, h: number): number {
+  return Math.min(Math.max(MIN_H, h), maxWindowHeight(vh));
+}
+
+export function termGeom(vw: number, vh: number, posts: PostFrontMatter[]): WinGeom {
+  const maxW = Math.max(MIN_W, vw - 40);
+  const targetW = Math.min(Math.round(vw * 0.8), termFitWidth(posts));
+  const w = Math.min(maxW, Math.max(MIN_W, targetW));
+  const h = clampWindowHeight(vh, Math.min(vh - 80, 620));
+  return { x: Math.round((vw - w) / 2), y: Math.max(20, Math.round((vh - h) / 2)), w, h };
+}
+
+export function showGeom(vw: number, vh: number): WinGeom {
+  const TERMINAL_ARTICLE_W = 840;
+  const SHOW_CHROME_W = 74;
+  const maxW = TERMINAL_ARTICLE_W + SHOW_CHROME_W;
+  const w = Math.max(MIN_W, Math.min(maxW, vw - 48));
+  const h = clampWindowHeight(vh, vh - 40);
+  return { x: Math.max(20, Math.round((vw - w) / 2)), y: Math.max(20, Math.round((vh - h) / 2)), w, h };
+}
+
+export function prsGeom(vw: number, vh: number): WinGeom {
+  const w = Math.max(MIN_W, Math.min(920, vw - 48));
+  const h = clampWindowHeight(vh, Math.min(PRS_WINDOW_MAX_H, vh - 64));
+  return { x: Math.max(20, Math.round((vw - w) / 2)), y: Math.max(20, Math.round((vh - h) / 2)), w, h };
+}
+
+export function legalGeom(vw: number, vh: number): WinGeom {
+  const w = Math.max(MIN_W, Math.min(740, vw - 48));
+  const h = clampWindowHeight(vh, Math.min(620, Math.round(vh * 0.78), vh - 64));
+  return { x: Math.max(20, Math.round((vw - w) / 2)), y: Math.max(20, Math.round((vh - h) / 2)), w, h };
+}
+
+export function clampWinToViewport(win: WinState, vw: number, vh: number): WinState {
+  const h = Math.min(win.h, maxWindowHeight(vh));
+  const targetW = win.id.startsWith('show:') && win.w >= LEGACY_SHOW_WINDOW_W ? Math.max(win.w, showGeom(vw, vh).w) : win.w;
+  const w = Math.max(MIN_W, Math.min(targetW, vw - win.x));
+  const x = Math.max(0, Math.min(win.x, vw - Math.min(w, 40)));
+  const y = Math.max(0, Math.min(win.y, vh - h));
+  return { ...win, x, y, w, h };
+}

--- a/components/retro-terminal/ids.ts
+++ b/components/retro-terminal/ids.ts
@@ -1,0 +1,8 @@
+import type { LegalWindowVariant } from './types';
+
+export const TERM_ID = 'term';
+export const PRS_ID = 'latest-prs';
+export const STORAGE_KEY = 'retro-terminal-state:v1';
+
+export const showWinId = (slug: string) => `show:${slug}`;
+export const legalWinId = (variant: LegalWindowVariant) => `legal:${variant}`;

--- a/components/retro-terminal/postUtils.ts
+++ b/components/retro-terminal/postUtils.ts
@@ -1,0 +1,13 @@
+import { isBranchTag } from '@/utils/graph';
+
+export const BRANCH_COLORS: Record<string, string> = {
+  graphql: '#3b8a9e',
+  homelab: '#7c5e9e',
+  react: '#9a4f00',
+  testing: '#3b6db8',
+  tooling: '#a8443a',
+  typescript: '#4a7c3a',
+};
+
+export const isBranch = (tag: string) => isBranchTag(tag);
+export const branchOf = (post: { tags: string[] }) => post.tags.find((t) => isBranch(t));

--- a/components/retro-terminal/types.ts
+++ b/components/retro-terminal/types.ts
@@ -1,0 +1,31 @@
+import type { MDXRemoteSerializeResult } from 'next-mdx-remote';
+
+export type WinGeom = { x: number; y: number; w: number; h: number };
+export type WinState = WinGeom & { id: string; z: number };
+export type OpenWin = { id: string; geom: WinGeom; z: number; focused: boolean };
+
+export type MdxState =
+  | { status: 'ready'; source: MDXRemoteSerializeResult }
+  | { status: 'error' };
+
+export type LatestPr = {
+  title: string;
+  url: string;
+  repo: string;
+  number: string;
+  publishedAt: string;
+};
+
+export type LatestPrsState =
+  | { status: 'loading' }
+  | { status: 'ready'; prs: LatestPr[] }
+  | { status: 'error' };
+
+export type LegalWindowVariant = 'disclaimer' | 'privacy-policy';
+
+export type CopyStatus = 'idle' | 'copying' | 'copied' | 'error';
+
+export type StoredTerminalState = {
+  cursor?: number;
+  windows?: WinState[];
+};

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,4 +1,5 @@
 import '@/styles/app.css';
+import '@/styles/retro.css';
 import 'rehype-callouts/theme/obsidian';
 import 'react-social-icons/bsky.app';
 import 'react-social-icons/github';
@@ -8,10 +9,41 @@ import 'react-social-icons/rss';
 import 'react-social-icons/x';
 
 import type { AppProps } from 'next/app';
+import dynamic from 'next/dynamic';
 import Script from 'next/script';
 
 import { SpeedInsights } from '@vercel/speed-insights/next';
 import { ThemeProvider } from 'next-themes';
+
+import { RetroModeProvider, useRetroMode } from '@/components/RetroModeContext';
+import type { PostFrontMatter } from '@/utils/mdx';
+
+const RetroTerminal = dynamic(() => import('@/components/RetroTerminal'), {
+  ssr: false,
+});
+
+type RetroPageProps = {
+  retroPosts?: PostFrontMatter[];
+};
+
+function RetroModeGate({
+  Component,
+  pageProps,
+}: {
+  Component: AppProps['Component'];
+  pageProps: AppProps['pageProps'];
+}) {
+  const { isRetro } = useRetroMode();
+  const retroProps = pageProps as RetroPageProps;
+  const posts = retroProps.retroPosts;
+
+  const showTerminal = isRetro && posts;
+
+  if (showTerminal) {
+    return <RetroTerminal posts={posts} />;
+  }
+  return <Component {...pageProps} />;
+}
 
 export default function App({ Component, pageProps }: AppProps) {
   return (
@@ -25,7 +57,9 @@ export default function App({ Component, pageProps }: AppProps) {
       />
 
       <ThemeProvider attribute="class">
-        <Component {...pageProps} />
+        <RetroModeProvider>
+          <RetroModeGate Component={Component} pageProps={pageProps} />
+        </RetroModeProvider>
         <SpeedInsights />
       </ThemeProvider>
     </>

--- a/pages/api/blog-mdx/[slug].ts
+++ b/pages/api/blog-mdx/[slug].ts
@@ -1,0 +1,17 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+import { getPostBySlug, getPosts } from '@/utils/mdx';
+
+const validSlugs = new Set(getPosts().map((post) => post.replace(/\.mdx$/, '')));
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const { slug } = req.query;
+
+  if (typeof slug !== 'string' || !validSlugs.has(slug)) {
+    return res.status(404).json({ error: 'Post not found' });
+  }
+
+  const { mdxSource } = await getPostBySlug(slug);
+  res.setHeader('Cache-Control', 'public, max-age=0, s-maxage=31536000, immutable');
+  return res.status(200).json({ mdxSource });
+}

--- a/pages/api/latestPrs.ts
+++ b/pages/api/latestPrs.ts
@@ -1,0 +1,59 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+type LatestPr = {
+  title: string;
+  url: string;
+  repo: string;
+  number: string;
+  publishedAt: string;
+};
+
+function decodeXml(text: string) {
+  return text
+    .replaceAll('&amp;', '&')
+    .replaceAll('&lt;', '<')
+    .replaceAll('&gt;', '>')
+    .replaceAll('&quot;', '"')
+    .replaceAll('&apos;', "'");
+}
+
+function readTag(item: string, tag: string) {
+  const match = new RegExp(String.raw`<${tag}>(?:<!\[CDATA\[)?([\s\S]*?)(?:\]\]>)?</${tag}>`).exec(item);
+  return match ? decodeXml(match[1].trim()) : '';
+}
+
+function parsePr(url: string) {
+  const match = /^https:\/\/github\.com\/([^/]+\/[^/]+)\/pull\/(\d+)$/.exec(url);
+  return { repo: match?.[1] ?? 'unknown/repo', number: match?.[2] ? `#${match[2]}` : '' };
+}
+
+function parseFeed(xml: string): LatestPr[] {
+  return [...xml.matchAll(/<item>([\s\S]*?)<\/item>/g)].slice(0, 12).map((match) => {
+    const item = match[1];
+    const title = readTag(item, 'title');
+    const url = readTag(item, 'link');
+    const { repo, number } = parsePr(url);
+    return {
+      title,
+      url,
+      repo,
+      number,
+      publishedAt: readTag(item, 'pubDate'),
+    };
+  });
+}
+
+export default async function handler(_req: NextApiRequest, res: NextApiResponse) {
+  let response: Response;
+  try {
+    response = await fetch('https://prs.charpeni.com/feed.xml');
+  } catch {
+    return res.status(502).json({ error: 'Failed to fetch latest PRs' });
+  }
+
+  if (!response.ok) return res.status(502).json({ error: 'Failed to fetch latest PRs' });
+
+  const xml = await response.text();
+  res.setHeader('Cache-Control', 'public, max-age=0, s-maxage=3600, stale-while-revalidate=86400');
+  return res.status(200).json({ prs: parseFeed(xml) });
+}

--- a/pages/api/latestPrs.ts
+++ b/pages/api/latestPrs.ts
@@ -1,12 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 
-type LatestPr = {
-  title: string;
-  url: string;
-  repo: string;
-  number: string;
-  publishedAt: string;
-};
+import type { LatestPr } from '@/components/retro-terminal/types';
 
 function decodeXml(text: string) {
   return text

--- a/pages/blog/[slug].tsx
+++ b/pages/blog/[slug].tsx
@@ -4,7 +4,7 @@ import { MDXRemote } from 'next-mdx-remote';
 
 import BlogLayout from '@/components/BlogLayout';
 import MDXComponents from '@/components/MDXComponents';
-import { getPosts, getPostBySlug } from '@/utils/mdx';
+import { getAllPostsFrontMatter, getPosts, getPostBySlug } from '@/utils/mdx';
 
 export default function Blog({
   mdxSource,
@@ -32,6 +32,7 @@ export async function getStaticPaths() {
 
 export async function getStaticProps({ params }: { params: { slug: string } }) {
   const post = await getPostBySlug(params.slug);
+  const posts = getAllPostsFrontMatter();
 
-  return { props: { ...post } };
+  return { props: { ...post, retroPosts: posts } };
 }

--- a/pages/disclaimer.tsx
+++ b/pages/disclaimer.tsx
@@ -1,4 +1,6 @@
 import Container from '@/components/Container';
+import { LegalContent } from '@/components/LegalContent';
+import { getAllPostsFrontMatter } from '@/utils/mdx';
 
 export default function Disclaimer() {
   return (
@@ -12,64 +14,14 @@ export default function Disclaimer() {
           DISCLAIMER
         </h1>
         <div className="max-w-prose text-gray-600 dark:text-gray-400">
-          <h2 className="prose font-bold">WEBSITE DISCLAIMER</h2>
-          <p>
-            The information provided by Nicolas Charpentier (&quot;we&quot;,
-            &quot;us&quot;, &quot;our&quot;) on{' '}
-            <a href="https://charpeni.com">https://charpeni.com</a> (the
-            &quot;Site&quot;) is for general informational purposes only. All
-            information on the Site is provided in good faith, however we make
-            no representation or warranty of any kind, express or implied,
-            regarding the accuracy, adequacy, validity, reliability,
-            availability or completeness of any information on the Site. UNDER
-            NO CIRCUMSTANCE SHALL WE HAVE ANY LIABILITY TO YOU FOR ANY LOSS OR
-            DAMAGE OF ANY KIND INCURRED AS A RESULT OF THE USE OF THE SITE OR
-            RELIANCE ON ANY INFORMATION PROVIDED ON THE SITE. YOUR USE OF THIS
-            SITE AND YOUR RELIANCE ON ANY INFORMATION ON THE SITE IS SOLELY AT
-            YOUR OWN RISK.
-          </p>
-          <h2 className="prose mt-4 font-bold">EXTERNAL LINKS DISCLAIMER</h2>
-          <p>
-            The Site may contain (or you may be sent through the Site) links to
-            other websites or content belonging to or originating from third
-            parties or links to websites and features in banners or other
-            advertising. Such external links are not investigated, monitored, or
-            checked for accuracy, adequacy, validity, reliability, availability
-            or completeness by us. WE DO NOT WARRANT, ENDORSE, GUARANTEE, OR
-            ASSUME RESPONSIBILITY FOR THE ACCURACY OR RELIABILITY OF ANY
-            INFORMATION OFFERED BY THIRD-PARTY WEBSITES LINKED THROUGH THE SITE
-            OR ANY WEBSITE OR FEATURE LINKED IN ANY BANNER OR OTHER ADVERTISING.
-            WE WILL NOT BE A PARTY TO OR IN ANY WAY BE RESPONSIBLE FOR
-            MONITORING ANY TRANSACTION BETWEEN YOU AND THIRD-PARTY PROVIDERS OF
-            PRODUCTS OR SERVICES.
-          </p>
-          <h2 className="prose mt-4 font-bold">TESTIMONIALS DISCLAIMER</h2>
-          <p className="mb-4">
-            The Site may contain testimonials by users of our products and/or
-            services. These testimonials reflect the real-life experiences and
-            opinions of such users. However, the experiences are personal to
-            those particular users, and may not necessarily be representative of
-            all users of our products and/or services. We do not claim, and you
-            should not assume, that all users will have the same experiences.
-            YOUR INDIVIDUAL RESULTS MAY VARY.
-          </p>
-          <p className="mb-4">
-            The testimonials on the Site are submitted in various forms such as
-            text, audio and/or video, and are reviewed by us before being
-            posted. They appear on the Site verbatim as given by the users,
-            except for the correction of grammar or typing errors. Some
-            testimonials may have been shortened for the sake of brevity where
-            the full testimonial contained extraneous information not relevant
-            to the general public.
-          </p>
-          <p>
-            The views and opinions contained in the testimonials belong solely
-            to the individual user and do not reflect our views and opinions. We
-            are not affiliated with users who provide testimonials, and users
-            are not paid or otherwise compensated for their testimonials.
-          </p>
+          <LegalContent variant="disclaimer" />
         </div>
       </div>
     </Container>
   );
+}
+
+export async function getStaticProps() {
+  const posts = getAllPostsFrontMatter();
+  return { props: { retroPosts: posts } };
 }

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -266,7 +266,6 @@ export default function Home({
 }
 
 export async function getStaticProps() {
-  const posts = await getAllPostsFrontMatter();
-
-  return { props: { posts } };
+  const posts = getAllPostsFrontMatter();
+  return { props: { posts, retroPosts: posts } };
 }

--- a/pages/privacy-policy.tsx
+++ b/pages/privacy-policy.tsx
@@ -1,6 +1,6 @@
-import NextLink from 'next/link';
-
 import Container from '@/components/Container';
+import { LegalContent } from '@/components/LegalContent';
+import { getAllPostsFrontMatter } from '@/utils/mdx';
 
 export default function PrivacyPolicy() {
   return (
@@ -14,30 +14,14 @@ export default function PrivacyPolicy() {
           PRIVACY POLICY
         </h1>
         <div className="max-w-prose text-gray-600 dark:text-gray-400">
-          <p>
-            This website (
-            <a href="https://charpeni.com">https://charpeni.com</a>) does not
-            directly collect personal data on behalf of its author (Nicolas
-            Charpentier) and uses no cookies.
-          </p>
-          <p className="mt-4">
-            This website is hosted on Vercel (
-            <a href="https://vercel.com">https://vercel.com</a>). As such, when
-            loading this website, your IP address will be available to Vercel
-            and may be stored in their access logs, along with the information
-            which page specifically you loaded.
-          </p>
-          <p className="mt-4">
-            From this website, you can visit other websites by following
-            hyperlinks to such external sites. These other sites may have
-            different privacy policies and terms which are beyond control of the
-            author of <a href="https://charpeni.com">https://charpeni.com</a>.
-            See this website&apos;s{' '}
-            <NextLink href="/disclaimer">Legal Disclaimer</NextLink> for more
-            information.
-          </p>
+          <LegalContent variant="privacy-policy" />
         </div>
       </div>
     </Container>
   );
+}
+
+export async function getStaticProps() {
+  const posts = getAllPostsFrontMatter();
+  return { props: { retroPosts: posts } };
 }

--- a/pages/tags/[tag].tsx
+++ b/pages/tags/[tag].tsx
@@ -25,6 +25,7 @@ type TagPost = Pick<
 type Props = {
   tag: string;
   posts: TagPost[];
+  retroPosts: PostMeta[];
 };
 
 export default function TagPage({
@@ -176,6 +177,7 @@ export const getStaticProps: GetStaticProps<Props> = async ({ params }) => {
     props: {
       tag,
       posts: filtered,
+      retroPosts: all,
     },
   };
 };

--- a/styles/retro.css
+++ b/styles/retro.css
@@ -1,0 +1,1257 @@
+/* Retro OS mode: cream-paper terminal.
+ * Global styles for the Terminal variant when retro mode is active.
+ */
+
+.retro-terminal-shell {
+  position: fixed;
+  inset: 0;
+  overflow: hidden;
+  user-select: none;
+  cursor: default;
+  z-index: 9999;
+}
+
+.retro-terminal-desktop {
+  position: absolute;
+  inset: 0;
+  background-color: #f4ecd8;
+  background-image: radial-gradient(circle, #d4c9a8 1px, transparent 1.5px);
+  background-size: 24px 24px;
+  background-position: 0 0;
+  color: #2a2a2a;
+  font-family: ui-monospace, "SF Mono", "Menlo", "JetBrains Mono", "Courier New", monospace;
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+.retro-terminal-crt {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background:
+    repeating-linear-gradient(0deg, rgba(42, 42, 42, 0.04) 0 1px, transparent 1px 3px),
+    radial-gradient(ellipse at center, transparent 62%, rgba(122, 113, 96, 0.14) 100%);
+  z-index: 1;
+}
+
+/* desktop launcher icon — shows when the terminal window is closed */
+.retro-terminal-launcher {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  z-index: 3;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+  padding: 16px 12px;
+  border: 0;
+  background: transparent;
+  cursor: pointer;
+  color: #2a2a2a;
+  font-family: inherit;
+  transition: transform 0.12s ease;
+}
+.retro-terminal-launcher:hover {
+  transform: translate(-50%, -50%) translateY(-2px);
+}
+.retro-terminal-launcher:focus-visible {
+  outline: 2px solid #b45309;
+  outline-offset: 4px;
+  border-radius: 8px;
+}
+.retro-terminal-launcher-glyph {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 64px;
+  height: 64px;
+  border-radius: 14px;
+  background: #fbf6e9;
+  border: 1px solid #2a2a2a;
+  color: #b45309;
+  box-shadow: 0 6px 18px rgba(42, 42, 42, 0.18);
+  transition: box-shadow 0.12s ease, color 0.12s ease;
+}
+.retro-terminal-launcher:hover .retro-terminal-launcher-glyph {
+  color: #2a2a2a;
+  box-shadow: 0 0 0 3px rgba(180, 83, 9, 0.18), 0 8px 22px rgba(42, 42, 42, 0.22);
+}
+.retro-terminal-launcher-label {
+  font-size: 12px;
+  letter-spacing: 0.08em;
+  text-transform: lowercase;
+  color: #5a5345;
+}
+
+.retro-terminal-window {
+  position: absolute;
+  background: #fbf6e9;
+  border: 1px solid #2a2a2a;
+  display: flex;
+  flex-direction: column;
+  min-width: 260px;
+  min-height: 160px;
+  z-index: 2;
+  box-shadow: 2px 3px 0 rgba(122, 113, 96, 0.18);
+  transform-origin: left bottom;
+}
+.retro-terminal-window:focus {
+  outline: none;
+}
+.retro-terminal-window--active {
+  box-shadow: 2px 3px 0 rgba(122, 113, 96, 0.22), inset 3px 0 0 0 #b45309;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .retro-terminal-window {
+    animation: retro-terminal-window-spawn 180ms cubic-bezier(0.18, 0.9, 0.28, 1.08) both;
+  }
+  .retro-terminal-window[data-retro-window-id="term"] {
+    animation-delay: 150ms;
+  }
+}
+
+@keyframes retro-terminal-window-spawn {
+  from {
+    opacity: 0;
+    transform: translate(-28px, 42px) scale(0.82);
+  }
+  72% {
+    opacity: 1;
+    transform: translate(0, 0) scale(1.015);
+  }
+  to {
+    opacity: 1;
+    transform: translate(0, 0) scale(1);
+  }
+}
+
+.retro-terminal-titlebar {
+  height: 24px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 0 10px;
+  background: #2a2a2a;
+  border-bottom: 1px solid #2a2a2a;
+  color: #f4ecd8;
+  cursor: grab;
+  font-size: 12px;
+  user-select: none;
+}
+.retro-terminal-titlebar--active {
+  background: #b45309;
+}
+.retro-terminal-dots {
+  display: inline-flex;
+  gap: 5px;
+}
+.retro-terminal-dot {
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  background: #7a7160;
+}
+.retro-terminal-title-text {
+  flex: 1;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  letter-spacing: 0.04em;
+}
+.retro-terminal-close {
+  width: 18px;
+  height: 18px;
+  border: 0;
+  background: transparent;
+  color: #d4c9a8;
+  font-size: 15px;
+  line-height: 1;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+.retro-terminal-close:hover {
+  background: #f4ecd8;
+  color: #b45309;
+}
+
+.retro-terminal-content {
+  flex: 1;
+  overflow: auto;
+  background: #fbf6e9;
+  padding: 10px 12px;
+  outline: none;
+}
+.retro-terminal-content:focus {
+  background: #fdf9ee;
+}
+
+.retro-terminal-profile {
+  position: absolute;
+  top: 56px;
+  left: 164px;
+  z-index: 0;
+  width: fit-content;
+  max-width: calc(100vw - 228px);
+  padding: 14px 16px 13px;
+  background: #fbf6e9;
+  border: 1px solid #d4c9a8;
+  border-left: 3px solid #b45309;
+  box-shadow: 3px 4px 0 rgba(122, 113, 96, 0.18);
+  color: #5a5345;
+  font-size: 12px;
+  line-height: 1.6;
+  pointer-events: auto;
+  user-select: text;
+  transform-origin: left top;
+  animation: retro-profile-container-enter 180ms cubic-bezier(0.18, 0.9, 0.28, 1.08) both;
+}
+
+@keyframes retro-profile-container-enter {
+  0% {
+    opacity: 0;
+    transform: translate(-8px, 10px) scale(0.92);
+  }
+  72% {
+    opacity: 1;
+    transform: translate(0, 0) scale(1.015);
+  }
+  100% {
+    opacity: 1;
+    transform: translate(0, 0) scale(1);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .retro-terminal-profile {
+    animation: none;
+  }
+}
+.retro-terminal-profile-icon {
+  position: absolute;
+  top: 56px;
+  left: 54px;
+  z-index: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 7px;
+  width: 96px;
+  padding: 9px 8px 8px;
+  color: #2a2a2a;
+  font-size: 10px;
+  line-height: 1.2;
+  text-align: center;
+  pointer-events: auto;
+  user-select: none;
+}
+.retro-terminal-profile-icon::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border: 1px dotted #b45309;
+  background: rgba(180, 83, 9, 0.08);
+  box-shadow: 2px 3px 0 rgba(122, 113, 96, 0.12);
+}
+.retro-terminal-profile-icon-glyph {
+  position: relative;
+  flex: 0 0 auto;
+  width: 58px;
+  height: 58px;
+  padding: 2px;
+  border: 1px solid #7a7160;
+  background: #fbf6e9;
+  box-shadow: 2px 3px 0 rgba(122, 113, 96, 0.16);
+  transform: rotate(-1.2deg);
+}
+.retro-terminal-profile-icon-glyph::after {
+  content: "";
+  position: absolute;
+  inset: 2px;
+  pointer-events: none;
+  background: repeating-linear-gradient(0deg, rgba(42, 42, 42, 0.08) 0 1px, transparent 1px 3px);
+  mix-blend-mode: soft-light;
+}
+.retro-terminal-profile-icon-img {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  filter: saturate(0.78) sepia(0.12) contrast(1.08) brightness(0.98);
+}
+.retro-terminal-profile-icon-label {
+  position: relative;
+  width: 100%;
+  padding: 1px 2px;
+  background: #b45309;
+  color: #fbf6e9;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.retro-terminal-profile-name {
+  color: #2a2a2a;
+  font-weight: 700;
+  font-size: 18px;
+  line-height: 1.25;
+}
+.retro-terminal-profile-email {
+  font-weight: 400;
+  font-size: 12px;
+}
+.retro-terminal-profile-role {
+  color: #5a5345;
+}
+.retro-terminal-profile-stack {
+  color: #b45309;
+  font-weight: 700;
+}
+.retro-terminal-profile-current {
+  color: #5a5345;
+}
+.retro-terminal-profile-email,
+.retro-terminal-profile-current a,
+.retro-terminal-profile-links a {
+  color: #b45309;
+  text-decoration: none;
+  border-bottom: 1px dotted #b45309;
+}
+.retro-terminal-profile-email:hover,
+.retro-terminal-profile-current a:hover,
+.retro-terminal-profile-links a:hover {
+  color: #9a4f00;
+  border-bottom-style: solid;
+}
+.retro-terminal-profile-links {
+  color: #7a7160;
+  margin-top: 2px;
+  font-size: 11px;
+  white-space: nowrap;
+}
+
+.retro-terminal-footer {
+  position: absolute;
+  right: 64px;
+  bottom: 32px;
+  z-index: 0;
+  width: fit-content;
+  max-width: calc(100vw - 128px);
+  padding: 10px 12px;
+  border: 1px solid #d4c9a8;
+  background: rgba(251, 246, 233, 0.92);
+  box-shadow: 3px 4px 0 rgba(122, 113, 96, 0.14);
+  color: #7a7160;
+  font-size: 11px;
+  line-height: 1.6;
+  text-align: right;
+  user-select: text;
+}
+.retro-terminal-footer-links {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  color: #a89b7e;
+}
+.retro-terminal-footer a,
+.retro-terminal-footer button {
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: #b45309;
+  font: inherit;
+  text-decoration: none;
+  border-bottom: 1px dotted #b45309;
+  cursor: pointer;
+}
+.retro-terminal-footer a:hover,
+.retro-terminal-footer button:hover {
+  color: #9a4f00;
+  border-bottom-style: solid;
+}
+
+@media (max-width: 900px) {
+  .retro-terminal-profile {
+    top: 48px;
+    left: 124px;
+    width: calc(100vw - 148px);
+    max-width: none;
+    padding: 12px 14px;
+  }
+  .retro-terminal-profile-links {
+    white-space: normal;
+  }
+  .retro-terminal-profile-icon {
+    top: 48px;
+    left: 24px;
+    width: 84px;
+  }
+  .retro-terminal-profile-icon-glyph {
+    width: 46px;
+    height: 46px;
+  }
+  .retro-terminal-footer {
+    right: 24px;
+    bottom: 20px;
+    max-width: calc(100vw - 48px);
+  }
+  .retro-terminal-profile-name {
+    font-size: 15px;
+  }
+}
+
+.retro-terminal-agent {
+  margin: 10px 12px 8px;
+  border: 1px solid #d4c9a8;
+  background: #fffaf0;
+  box-shadow: 1px 2px 0 rgba(122, 113, 96, 0.12);
+}
+.retro-terminal-agent-user,
+.retro-terminal-agent-step {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 5px 9px;
+  border-bottom: 1px solid #ede4cc;
+  color: #2a2a2a;
+  white-space: pre-wrap;
+}
+.retro-terminal-agent-user {
+  font-weight: 700;
+}
+.retro-terminal-agent-step {
+  color: #5a5345;
+}
+.retro-terminal-agent-mark {
+  color: #b45309;
+  font-size: 15px;
+  font-weight: 700;
+}
+.retro-terminal-agent-orb {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: #b45309;
+  box-shadow: 0 0 0 2px rgba(180, 83, 9, 0.12);
+}
+.retro-terminal-agent-tool {
+  padding: 6px 9px 7px;
+  background: #f4ecd8;
+}
+.retro-terminal-agent-tool--pending {
+  color: #7a7160;
+  opacity: 0.76;
+}
+.retro-terminal-agent-tool-name {
+  margin-bottom: 2px;
+  color: #7a7160;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+}
+.retro-terminal-prompt-cmd {
+  color: #2a2a2a;
+  font-weight: 600;
+}
+.retro-terminal-agent-dots::after {
+  content: "";
+  animation: retro-terminal-agent-dots 1.1s steps(4, end) infinite;
+}
+.retro-terminal-content--loading {
+  display: flex;
+  align-items: flex-start;
+  color: #7a7160;
+}
+.retro-terminal-loading-line {
+  padding: 2px 0;
+}
+
+@keyframes retro-terminal-agent-dots {
+  0% {
+    content: "";
+  }
+  25% {
+    content: ".";
+  }
+  50% {
+    content: "..";
+  }
+  75%,
+  100% {
+    content: "...";
+  }
+}
+.retro-terminal-prompt-meta {
+  color: #7a7160;
+  margin: 0 0 10px;
+  padding: 0 12px;
+  white-space: pre-wrap;
+}
+
+.retro-terminal-log {
+  display: flex;
+  flex-direction: column;
+}
+
+.retro-terminal-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-height: 22px;
+  padding: 0 6px;
+  cursor: pointer;
+  white-space: pre;
+}
+.retro-terminal-row:hover {
+  background: #ede4cc;
+}
+.retro-terminal-row--selected {
+  background: #f7ead0;
+}
+
+.retro-terminal-graph {
+  flex: 0 0 auto;
+  overflow: visible;
+}
+.retro-terminal-graph-line {
+  fill: none;
+  stroke-width: 1.5;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  opacity: 0.82;
+  vector-effect: non-scaling-stroke;
+}
+.retro-terminal-graph-orb {
+  stroke: #fbf6e9;
+  stroke-width: 1.8;
+  vector-effect: non-scaling-stroke;
+}
+.retro-terminal-graph-orb--main {
+  fill: #2a2a2a;
+}
+.retro-terminal-hash {
+  color: #b45309;
+  font-weight: 600;
+  flex-shrink: 0;
+}
+.retro-terminal-date {
+  color: #7a7160;
+  flex-shrink: 0;
+  font-size: 11px;
+}
+.retro-terminal-refs {
+  flex-shrink: 0;
+  font-size: 12px;
+}
+.retro-terminal-msg {
+  color: #2a2a2a;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.retro-terminal-status {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 3px 12px;
+  background: #f4ecd8;
+  border-top: 1px solid #2a2a2a;
+  color: #7a7160;
+  font-size: 11px;
+  letter-spacing: 0.06em;
+  user-select: none;
+}
+.retro-terminal-status b {
+  color: #2a2a2a;
+  font-weight: 600;
+}
+.retro-terminal-status-hint {
+  opacity: 0.65;
+}
+
+.retro-terminal-prs-window {
+  display: flex;
+  flex: 1;
+  min-height: 0;
+  flex-direction: column;
+  background: #fbf6e9;
+}
+.retro-terminal-prs-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  border-bottom: 1px solid #d8c7a6;
+  padding: 8px 10px;
+  color: #7a7160;
+  font-size: 12px;
+}
+.retro-terminal-prs-toolbar a {
+  flex-shrink: 0;
+  color: #b45309;
+  font-weight: 700;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+.retro-terminal-prs-list {
+  flex: 1;
+  min-height: 0;
+  overflow: auto;
+  padding: 8px;
+  background: #fbf6e9;
+}
+.retro-terminal-prs-message {
+  padding: 10px;
+  color: #7a7160;
+}
+.retro-terminal-prs-row {
+  display: grid;
+  grid-template-columns: 58px 1fr;
+  gap: 10px;
+  border-bottom: 1px solid #eadfc9;
+  padding: 9px 8px;
+  color: #2a2a2a;
+  text-decoration: none;
+}
+.retro-terminal-prs-row:hover {
+  background: #f7ead0;
+}
+.retro-terminal-prs-number {
+  color: #b45309;
+  font-weight: 700;
+}
+.retro-terminal-prs-copy {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 3px;
+}
+.retro-terminal-prs-title {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-weight: 700;
+}
+.retro-terminal-prs-repo {
+  overflow: hidden;
+  color: #7a7160;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.retro-terminal-legal-window {
+  flex: 1;
+  min-height: 0;
+  overflow: auto;
+  padding: 16px 22px 18px;
+  background: #fbf6e9;
+  color: #2a2a2a;
+  user-select: text;
+}
+.retro-terminal-legal-title {
+  margin-bottom: 12px;
+  color: #b45309;
+  font-size: 14px;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+}
+.retro-terminal-legal-content {
+  max-width: 68ch;
+  color: #5a5345;
+  font-size: 13px;
+  line-height: 1.7;
+}
+.retro-terminal-legal-content h2 {
+  margin: 18px 0 6px;
+  color: #2a2a2a;
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+}
+.retro-terminal-legal-content h2:first-child {
+  margin-top: 0;
+}
+.retro-terminal-legal-content p {
+  margin: 0 0 12px;
+}
+.retro-terminal-legal-content a {
+  color: #b45309;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+/* git show window */
+.retro-terminal-show-meta {
+  color: #7a7160;
+  margin: 0 0 10px;
+  white-space: pre-wrap;
+}
+.retro-terminal-show-meta a {
+  color: #b45309;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+.retro-terminal-show-title {
+  color: #2a2a2a;
+  font-size: 15px;
+  font-weight: 700;
+  margin: 0 0 8px;
+}
+.retro-terminal-show-scroll {
+  flex: 1;
+  overflow: auto;
+  padding: 12px 28px 14px;
+  scrollbar-gutter: stable;
+}
+.retro-terminal-banner {
+  position: relative;
+  width: min(100%, 560px);
+  aspect-ratio: 2 / 1;
+  margin: 12px auto 1.25em;
+  overflow: hidden;
+  border-radius: 6px;
+  background: #ede4cc;
+}
+.retro-terminal-banner-img {
+  object-fit: cover;
+}
+.retro-terminal-open-link {
+  display: inline-block;
+  border: 0;
+  border-bottom: 1px solid #b45309;
+  padding: 0 0 1px;
+  background: transparent;
+  color: #b45309;
+  text-decoration: none;
+  font-weight: 600;
+  font-size: 12px;
+  letter-spacing: 0.04em;
+  cursor: pointer;
+}
+.retro-terminal-open-link:hover {
+  color: #2a2a2a;
+  border-bottom-color: #2a2a2a;
+}
+.retro-terminal-comments {
+  margin-top: 36px;
+  padding-top: 16px;
+  border-top: 1px solid #d4c9a8;
+}
+.retro-terminal-comments-title {
+  margin-bottom: 12px;
+  color: #7a7160;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+.retro-terminal-comments iframe {
+  color-scheme: light;
+}
+
+/* resize handle */
+.retro-terminal-resize {
+  position: absolute;
+  bottom: 0;
+  right: 0;
+  width: 18px;
+  height: 18px;
+  cursor: nwse-resize;
+  display: flex;
+  align-items: flex-end;
+  justify-content: flex-end;
+  color: #a89b7e;
+  font-size: 12px;
+  line-height: 1;
+  user-select: none;
+  z-index: 5;
+  padding: 0 2px 2px 0;
+}
+.retro-terminal-resize:hover {
+  color: #b45309;
+}
+
+/* prose overrides for cream-paper show window */
+.retro-terminal-prose {
+  max-width: none;
+  color: #2a2a2a;
+  font-size: 14px;
+  line-height: 1.7;
+}
+.retro-terminal-prose h1,
+.retro-terminal-prose h2,
+.retro-terminal-prose h3,
+.retro-terminal-prose h4 {
+  color: #2a2a2a;
+}
+.retro-terminal-prose a {
+  color: #b45309;
+}
+.retro-terminal-prose a:hover {
+  color: #9a4f00;
+}
+.retro-terminal-prose [class*="sandpackContainer"] {
+  width: 100%;
+  max-width: 100%;
+  margin: 1.5em 0 2em;
+}
+.retro-terminal-prose .sp-wrapper {
+  border: 1px solid #2a2a2a;
+  border-radius: 0;
+  box-shadow: 2px 3px 0 rgba(122, 113, 96, 0.16);
+  overflow: hidden;
+}
+.retro-terminal-prose .sp-layout {
+  border: 0;
+  border-radius: 0;
+}
+.retro-terminal-prose .sp-stack {
+  min-width: 0;
+}
+.retro-terminal-prose .sp-code-editor,
+.retro-terminal-prose .sp-preview-container {
+  min-width: 0;
+}
+.retro-terminal-prose .sp-preview-container iframe {
+  background: #fff;
+}
+@media (max-width: 760px) {
+  .retro-terminal-prose .sp-layout {
+    flex-direction: column;
+  }
+  .retro-terminal-prose .sp-code-editor,
+  .retro-terminal-prose .sp-preview-container {
+    width: 100% !important;
+  }
+}
+.retro-terminal-prose :not(pre) > code {
+  border: 1px solid #d4c9a8;
+  background: #fffaf0;
+  color: #9a4f00;
+  padding: 0.08em 0.32em;
+  border-radius: 0;
+  font-size: 0.9em;
+}
+.retro-terminal-prose :not(pre) > code::before,
+.retro-terminal-prose :not(pre) > code::after {
+  content: "";
+}
+.retro-terminal-prose pre {
+  position: relative;
+  margin: 1.35em 0;
+  border: 1px solid #2a2a2a;
+  border-radius: 0;
+  background: #fffaf0 !important;
+  color: #2a2a2a;
+  box-shadow: 2px 3px 0 rgba(122, 113, 96, 0.16);
+  font-size: 12px;
+  line-height: 1.65;
+  tab-size: 2;
+}
+.retro-terminal-prose pre::before {
+  content: "$ cat source";
+  display: block;
+  margin: -1.25em -1.5em 1em;
+  padding: 4px 10px;
+  border-bottom: 1px solid #2a2a2a;
+  background: #f4ecd8;
+  color: #7a7160;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+}
+.retro-terminal-prose pre code {
+  background: transparent !important;
+  color: inherit;
+  text-shadow: none;
+  font-family: ui-monospace, "SF Mono", "Menlo", "JetBrains Mono", "Courier New", monospace;
+}
+.retro-terminal-prose pre code::before,
+.retro-terminal-prose pre code::after {
+  content: "";
+}
+.retro-terminal-prose .code-block {
+  position: relative;
+}
+.retro-terminal-prose .code-block pre {
+  padding-right: 1.5em;
+}
+.retro-terminal-prose .copy-code-button {
+  top: 37px;
+  right: 10px;
+  width: 26px;
+  height: 26px;
+  border: 1px solid #d4c9a8;
+  border-radius: 0;
+  background: #fffaf0;
+  color: #7a7160;
+}
+.retro-terminal-prose .copy-code-button:hover {
+  background: #f4ecd8;
+  color: #b45309;
+}
+.retro-terminal-prose .rehype-code-title + .code-block .copy-code-button {
+  top: 8px;
+}
+.retro-terminal-prose pre .token.comment,
+.retro-terminal-prose pre .token.prolog,
+.retro-terminal-prose pre .token.doctype,
+.retro-terminal-prose pre .token.cdata {
+  color: #7a7160;
+}
+.retro-terminal-prose pre .token.punctuation,
+.retro-terminal-prose pre .token.operator {
+  color: #5a5345;
+}
+.retro-terminal-prose pre .token.keyword,
+.retro-terminal-prose pre .token.selector,
+.retro-terminal-prose pre .token.important {
+  color: #a8443a;
+  font-weight: 700;
+}
+.retro-terminal-prose pre .token.string,
+.retro-terminal-prose pre .token.attr-value {
+  color: #4a7c3a;
+}
+.retro-terminal-prose pre .token.function,
+.retro-terminal-prose pre .token.class-name {
+  color: #3b6db8;
+}
+.retro-terminal-prose pre .token.number,
+.retro-terminal-prose pre .token.boolean,
+.retro-terminal-prose pre .token.constant,
+.retro-terminal-prose pre .token.property,
+.retro-terminal-prose pre .token.attr-name {
+  color: #9a4f00;
+}
+.retro-terminal-prose blockquote {
+  border-left-color: #b45309;
+  color: #5a5345;
+}
+.retro-terminal-prose strong {
+  color: #2a2a2a;
+}
+.retro-terminal-prose .mdx-marker {
+  background: #ede4cc;
+  border-left-color: #b45309;
+}
+.retro-terminal-prose .rehype-code-title {
+  margin-bottom: 0 !important;
+  border: 1px solid #2a2a2a;
+  border-bottom: 0;
+  border-radius: 0;
+  background: #f4ecd8;
+  color: #7a7160;
+  padding: 5px 10px;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+}
+.retro-terminal-prose .rehype-code-title::before {
+  content: "$ cat ";
+  color: #b45309;
+}
+.retro-terminal-prose .rehype-code-title + pre,
+.retro-terminal-prose .rehype-code-title + .code-block pre {
+  margin-top: 0;
+  border-top: 1px solid #2a2a2a;
+}
+.retro-terminal-prose .rehype-code-title + pre::before,
+.retro-terminal-prose .rehype-code-title + .code-block pre::before {
+  display: none;
+}
+.retro-terminal-prose .sp-wrapper pre {
+  margin: 0;
+  border: 0;
+  background: transparent !important;
+  box-shadow: none;
+  color: inherit;
+  font-size: inherit;
+  line-height: inherit;
+}
+.retro-terminal-prose .sp-wrapper pre::before,
+.retro-terminal-prose .sp-wrapper code::before,
+.retro-terminal-prose .sp-wrapper code::after {
+  content: none;
+}
+.retro-terminal-prose .sp-wrapper code {
+  border: 0;
+  background: transparent !important;
+  color: inherit;
+  padding: 0;
+  font-size: inherit;
+}
+.retro-terminal-prose img {
+  border-radius: 6px;
+}
+.retro-terminal-image-frame img {
+  display: block;
+  width: 100%;
+  height: 100%;
+}
+.retro-terminal-image-frame {
+  display: block;
+  max-width: min(100%, 640px);
+  margin: 1.25em auto;
+}
+.retro-terminal-prose .img-center,
+.retro-terminal-prose figure.img-center {
+  max-width: 100% !important;
+  justify-content: center;
+}
+.retro-terminal-prose figure.img-zoom {
+  max-width: 320px !important;
+}
+.retro-terminal-prose .img-center .retro-terminal-image-frame,
+.retro-terminal-prose figure.img-center .retro-terminal-image-frame {
+  margin: 0;
+}
+.retro-terminal-loading-post {
+  min-height: 380px;
+  padding-top: 4px;
+}
+.retro-terminal-skeleton-line,
+.retro-terminal-skeleton-image {
+  position: relative;
+  overflow: hidden;
+  background: #ede4cc;
+  border: 1px solid #d4c9a8;
+}
+.retro-terminal-skeleton-line {
+  width: 78%;
+  height: 13px;
+  margin: 12px 0;
+}
+.retro-terminal-skeleton-line--wide {
+  width: 92%;
+}
+.retro-terminal-skeleton-line--short {
+  width: 54%;
+}
+.retro-terminal-skeleton-image {
+  width: min(100%, 620px);
+  aspect-ratio: 16 / 9;
+  margin: 18px auto;
+  border-radius: 6px;
+}
+.retro-terminal-skeleton-line::after,
+.retro-terminal-skeleton-image::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  transform: translateX(-100%);
+  background: linear-gradient(90deg, transparent, rgba(255, 250, 240, 0.72), transparent);
+  animation: retro-terminal-skeleton 1.25s ease-in-out infinite;
+}
+
+@keyframes retro-terminal-skeleton {
+  to {
+    transform: translateX(100%);
+  }
+}
+
+/* callouts as stamped paper notes */
+.retro-terminal-prose .callout {
+  position: relative;
+  margin: 1.85em 0 1.55em;
+  padding: 28px 18px 10px;
+  border: 1px solid #7a7160;
+  border-left: 3px solid #7a7160;
+  border-radius: 0;
+  background: #fbf6e9;
+  overflow: visible;
+  box-shadow: 3px 4px 0 rgba(122, 113, 96, 0.16);
+}
+.retro-terminal-prose .callout-title {
+  position: absolute;
+  top: -12px;
+  left: 12px;
+  display: inline-flex;
+  align-items: center;
+  gap: 0;
+  max-width: calc(100% - 24px);
+  padding: 1px 8px 2px;
+  font-family: ui-monospace, "SF Mono", "Menlo", monospace;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  line-height: 1.45;
+  text-transform: uppercase;
+  border: 1px solid currentColor;
+  background: #fbf6e9;
+  color: #7a7160;
+  transform: rotate(-0.6deg);
+  box-shadow: 1px 2px 0 rgba(122, 113, 96, 0.12);
+}
+.retro-terminal-prose .callout-title-icon {
+  display: none;
+}
+.retro-terminal-prose .callout-title-text::before {
+  content: '[';
+  margin-right: 3px;
+  opacity: 0.52;
+}
+.retro-terminal-prose .callout-title-text::after {
+  content: ']';
+  margin-left: 3px;
+  opacity: 0.52;
+}
+.retro-terminal-prose .callout-content {
+  padding: 0;
+  color: #3f3a32;
+}
+.retro-terminal-prose .callout-content > :first-child {
+  margin-top: 0;
+}
+.retro-terminal-prose .callout-content > :last-child {
+  margin-bottom: 0;
+}
+
+/* per-type accent colors */
+.retro-terminal-prose [data-callout="note"] {
+  border-left-color: #3b6db8;
+}
+.retro-terminal-prose [data-callout="note"] .callout-title {
+  color: #3b6db8;
+}
+.retro-terminal-prose [data-callout="tip"] {
+  border-left-color: #4a7c3a;
+}
+.retro-terminal-prose [data-callout="tip"] .callout-title {
+  color: #4a7c3a;
+}
+.retro-terminal-prose [data-callout="warning"] {
+  border-left-color: #9a4f00;
+}
+.retro-terminal-prose [data-callout="warning"] .callout-title {
+  color: #9a4f00;
+}
+.retro-terminal-prose [data-callout="caution"] {
+  border-left-color: #a8443a;
+}
+.retro-terminal-prose [data-callout="caution"] .callout-title {
+  color: #a8443a;
+}
+.retro-terminal-prose [data-callout="info"] {
+  border-left-color: #3b8a9e;
+}
+.retro-terminal-prose [data-callout="info"] .callout-title {
+  color: #3b8a9e;
+}
+.retro-terminal-prose [data-callout="important"] {
+  border-left-color: #7c5e9e;
+}
+.retro-terminal-prose [data-callout="important"] .callout-title {
+  color: #7c5e9e;
+}
+.retro-terminal-prose .callout:not([data-callout="note"]):not([data-callout="tip"]):not([data-callout="warning"]):not([data-callout="caution"]):not([data-callout="info"]):not([data-callout="important"]) {
+  border-left-color: #7a7160;
+}
+.retro-terminal-prose .callout:not([data-callout="note"]):not([data-callout="tip"]):not([data-callout="warning"]):not([data-callout="caution"]):not([data-callout="info"]):not([data-callout="important"]) .callout-title {
+  color: #5a5345;
+}
+
+/* keep text selectable */
+.retro-terminal-content,
+.retro-terminal-show-scroll {
+  user-select: text;
+}
+
+/* compact retro-mode trigger for the normal site header */
+.retro-mode-trigger {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  padding: 0;
+  border: 0;
+  border-radius: 6px;
+  font-family: ui-monospace, "SF Mono", "Menlo", monospace;
+  font-size: 13px;
+  font-weight: 700;
+  letter-spacing: -0.04em;
+  cursor: pointer;
+  transition: background-color 200ms, color 200ms, text-shadow 200ms;
+}
+.retro-mode-trigger--normal {
+  background: transparent;
+  color: #9ca3af;
+}
+:is(.dark .retro-mode-trigger--normal) {
+  background: transparent;
+  color: #6b7280;
+}
+.retro-mode-trigger--normal:hover {
+  color: #b45309;
+  background: rgba(180, 83, 9, 0.06);
+  text-shadow: 0 0 8px rgba(180, 83, 9, 0.24);
+}
+.retro-mode-trigger--retro {
+  border: 1px solid #2a2a2a;
+  background: #fbf6e9;
+  color: #b45309;
+}
+.retro-mode-trigger--retro:hover {
+  background: #f7ead0;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .retro-mode-trigger--normal {
+    animation: retro-mode-trigger-glow 4.8s ease-in-out infinite;
+  }
+}
+
+@keyframes retro-mode-trigger-glow {
+  0%,
+  58% {
+    color: #9ca3af;
+    text-shadow: none;
+  }
+  68% {
+    color: #b45309;
+    text-shadow: 0 0 8px rgba(180, 83, 9, 0.28);
+  }
+  82%,
+  100% {
+    color: #9ca3af;
+    text-shadow: none;
+  }
+}
+
+/* exit button inside the retro terminal shell */
+.retro-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 0 10px;
+  font-family: ui-monospace, "SF Mono", "Menlo", monospace;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  cursor: pointer;
+  border-radius: 6px;
+  transition: background-color 200ms, color 200ms, border-color 200ms;
+  white-space: nowrap;
+}
+.retro-toggle--retro {
+  border: 1px solid #2a2a2a;
+  background: #fbf6e9;
+  color: #b45309;
+}
+.retro-toggle--retro:hover {
+  background: #f7ead0;
+}
+.retro-toggle-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+.retro-toggle--retro .retro-toggle-dot {
+  background: #b45309;
+}

--- a/styles/retro.css
+++ b/styles/retro.css
@@ -403,6 +403,66 @@
   }
 }
 
+@media (max-width: 639px) {
+  .retro-terminal-shell {
+    overflow: hidden;
+  }
+  .retro-terminal-desktop {
+    font-size: 12px;
+    background-size: 18px 18px;
+  }
+  .retro-terminal-crt {
+    opacity: 0.72;
+  }
+  .retro-terminal-profile-icon {
+    top: 56px;
+    left: 14px;
+    width: 70px;
+    padding: 7px 6px;
+  }
+  .retro-terminal-profile-icon-glyph {
+    width: 38px;
+    height: 38px;
+  }
+  .retro-terminal-profile-icon-label {
+    font-size: 9px;
+  }
+  .retro-terminal-profile {
+    top: 56px;
+    left: 94px;
+    width: calc(100vw - 108px);
+    max-height: 116px;
+    overflow: hidden;
+    padding: 9px 10px;
+    font-size: 10px;
+    line-height: 1.45;
+  }
+  .retro-terminal-profile-name {
+    font-size: 13px;
+  }
+  .retro-terminal-profile-email,
+  .retro-terminal-profile-current,
+  .retro-terminal-profile-links {
+    display: none;
+  }
+  .retro-terminal-footer {
+    display: none;
+  }
+  .retro-terminal-agent {
+    margin: 8px;
+  }
+  .retro-terminal-agent-user,
+  .retro-terminal-agent-step {
+    padding: 6px 8px;
+  }
+  .retro-terminal-agent-tool {
+    padding: 7px 8px;
+  }
+  .retro-terminal-agent-tool-name {
+    font-size: 10px;
+  }
+}
+
 .retro-terminal-agent {
   margin: 10px 12px 8px;
   border: 1px solid #d4c9a8;
@@ -1254,4 +1314,192 @@
 }
 .retro-toggle--retro .retro-toggle-dot {
   background: #b45309;
+}
+
+/* Final responsive overrides must stay last so they win over component sections above. */
+@media (max-width: 900px) {
+  .retro-terminal-titlebar {
+    min-height: 36px;
+    height: 36px;
+    padding: 0 6px 0 12px;
+  }
+  .retro-terminal-close {
+    width: 36px;
+    height: 36px;
+    font-size: 18px;
+  }
+  .retro-terminal-resize {
+    width: 36px;
+    height: 36px;
+    padding: 0 6px 6px 0;
+    font-size: 16px;
+  }
+  .retro-terminal-row {
+    min-height: 32px;
+    padding: 3px 8px;
+  }
+  .retro-terminal-status {
+    min-height: 36px;
+    padding: 6px 12px;
+  }
+}
+
+@media (max-width: 639px) {
+  .retro-toggle--retro {
+    top: 10px !important;
+    right: 10px !important;
+    min-height: 40px;
+    height: 40px !important;
+    padding: 0 11px;
+    font-size: 10px;
+  }
+  .retro-terminal-window {
+    position: fixed !important;
+    left: 10px !important;
+    right: 10px !important;
+    top: 184px !important;
+    bottom: 70px !important;
+    width: auto !important;
+    height: auto !important;
+    min-width: 0;
+    min-height: 0;
+    max-height: none;
+    box-shadow: 2px 3px 0 rgba(122, 113, 96, 0.18), inset 3px 0 0 0 #b45309;
+  }
+  .retro-terminal-window:not(.retro-terminal-window--active) {
+    display: none;
+  }
+  .retro-terminal-titlebar {
+    height: 44px;
+    min-height: 44px;
+    gap: 7px;
+    padding: 0 0 0 10px;
+    cursor: default;
+  }
+  .retro-terminal-title-text {
+    font-size: 11px;
+    letter-spacing: 0.02em;
+  }
+  .retro-terminal-close {
+    width: 44px;
+    height: 44px;
+    font-size: 20px;
+  }
+  .retro-terminal-content {
+    padding: 6px 7px 10px;
+  }
+  .retro-terminal-log {
+    gap: 7px;
+  }
+  .retro-terminal-row {
+    display: grid;
+    grid-template-columns: 1fr;
+    grid-template-areas:
+      "title"
+      "meta";
+    align-items: center;
+    gap: 2px;
+    min-height: 62px;
+    padding: 8px;
+    border: 1px solid #eadfc9;
+    background: #fffaf0;
+    white-space: normal;
+  }
+  .retro-terminal-row:hover,
+  .retro-terminal-row--selected {
+    border-color: #2a2a2a;
+    background: #f7ead0;
+  }
+  .retro-terminal-msg {
+    grid-area: title;
+    display: -webkit-box;
+    overflow: hidden;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
+    font-size: 13px;
+    font-weight: 700;
+    line-height: 1.3;
+    text-overflow: clip;
+  }
+  .retro-terminal-hash,
+  .retro-terminal-date,
+  .retro-terminal-refs {
+    grid-area: meta;
+    font-size: 10px;
+  }
+  .retro-terminal-hash {
+    justify-self: start;
+  }
+  .retro-terminal-date {
+    justify-self: center;
+  }
+  .retro-terminal-refs {
+    justify-self: end;
+  }
+  .retro-terminal-status {
+    min-height: 42px;
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 1px;
+    padding: 6px 9px;
+    font-size: 10px;
+    line-height: 1.35;
+  }
+  .retro-terminal-window[data-retro-window-id="term"] .retro-terminal-status-hint {
+    font-size: 0;
+  }
+  .retro-terminal-window[data-retro-window-id="term"] .retro-terminal-status-hint::after {
+    content: "tap a commit to open";
+    font-size: 10px;
+  }
+  .retro-terminal-show-scroll {
+    padding: 10px 14px 14px;
+  }
+  .retro-terminal-show-title {
+    font-size: 17px;
+    line-height: 1.35;
+  }
+  .retro-terminal-show-meta {
+    font-size: 10px;
+  }
+  .retro-terminal-prose {
+    font-size: 15px;
+    line-height: 1.75;
+  }
+  .retro-terminal-prose h2 {
+    font-size: 1.25em;
+    line-height: 1.25;
+  }
+  .retro-terminal-prose pre {
+    margin-right: -6px;
+    margin-left: -6px;
+    font-size: 11px;
+  }
+  .retro-terminal-banner {
+    width: 100%;
+    border-radius: 4px;
+  }
+  .retro-terminal-comments,
+  .retro-terminal-window[data-retro-window-id^="show:"] {
+    top: 58px !important;
+    bottom: 10px !important;
+  }
+  .retro-terminal-resize {
+    display: none;
+  }
+  .retro-terminal-prs-toolbar {
+    align-items: flex-start;
+    flex-direction: column;
+    padding: 10px;
+  }
+  .retro-terminal-prs-row {
+    grid-template-columns: 48px 1fr;
+    min-height: 58px;
+  }
+  .retro-terminal-prs-title {
+    white-space: normal;
+  }
+  .retro-terminal-legal-window {
+    padding: 14px 16px 18px;
+  }
 }

--- a/styles/retro.css
+++ b/styles/retro.css
@@ -879,7 +879,7 @@
 .retro-terminal-prose .sp-preview-container iframe {
   background: #fff;
 }
-@media (max-width: 760px) {
+@media (max-width: 639px) {
   .retro-terminal-prose .sp-layout {
     flex-direction: column;
   }
@@ -1316,6 +1316,14 @@
   background: #b45309;
 }
 
+.retro-terminal-exit {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  z-index: 99999;
+  height: 32px;
+}
+
 /* Final responsive overrides must stay last so they win over component sections above. */
 @media (max-width: 900px) {
   .retro-terminal-titlebar {
@@ -1346,21 +1354,21 @@
 
 @media (max-width: 639px) {
   .retro-toggle--retro {
-    top: 10px !important;
-    right: 10px !important;
+    top: 10px;
+    right: 10px;
     min-height: 40px;
-    height: 40px !important;
+    height: 40px;
     padding: 0 11px;
     font-size: 10px;
   }
   .retro-terminal-window {
-    position: fixed !important;
-    left: 10px !important;
-    right: 10px !important;
-    top: 184px !important;
-    bottom: 70px !important;
-    width: auto !important;
-    height: auto !important;
+    position: fixed;
+    left: 10px;
+    right: 10px;
+    top: 184px;
+    bottom: 70px;
+    width: auto;
+    height: auto;
     min-width: 0;
     min-height: 0;
     max-height: none;
@@ -1479,10 +1487,9 @@
     width: 100%;
     border-radius: 4px;
   }
-  .retro-terminal-comments,
   .retro-terminal-window[data-retro-window-id^="show:"] {
-    top: 58px !important;
-    bottom: 10px !important;
+    top: 58px;
+    bottom: 10px;
   }
   .retro-terminal-resize {
     display: none;

--- a/utils/graph.ts
+++ b/utils/graph.ts
@@ -282,3 +282,18 @@ export function computeGraph(
 
   return { activeBranches, rows };
 }
+
+/**
+ * A short, deterministic 7-char hex "commit hash" for a post slug.
+ * Not cryptographically meaningful; just a stable pseudo-hash so the
+ * terminal's `git log` output looks right and `git show <hash>` is
+ * stable across renders.
+ */
+export function shortHash(slug: string): string {
+  let h = 2_166_136_261;
+  for (const ch of slug) {
+    h ^= ch.codePointAt(0) ?? 0;
+    h = Math.imul(h, 16_777_619);
+  }
+  return (h >>> 0).toString(16).padStart(8, '0').slice(0, 7);
+}


### PR DESCRIPTION
## Retro terminal mode

An opt-in terminal-styled interface for browsing the blog. Activated via the "Enter Terminal" toggle or the `retro-os=1` cookie.

### What's included

**Terminal experience**
- Git-log-style blog archive with branch graph, animated agent prompt, and keyboard navigation (`↑`/`↓`/`Enter`)
- `git show`-style post reader with lazy-loaded MDX
- Window manager: drag, resize, double-click title to reset, Escape to close
- Native rendering of latest PRs, disclaimer, and privacy policy in retro windows
- URL syncs to `/blog/<slug>` without full page navigation
- Copy-as-markdown with insecure-origin clipboard fallback
- State persisted to `localStorage`

**Responsive UX**
- **Desktop**: full windowed desktop with profile panel and footer
- **Tablet** (`< 900px`): larger touch targets, single-tap to open, git graph hidden
- **Phone** (`< 640px`): single-pane full-screen active window, card-style archive rows, post reader below the exit button

### How to test
1. Toggle "Enter Terminal" in the header, or visit with the `retro-os=1` cookie
2. Browse posts via keyboard or tap; open/close/resize windows
3. Try the latest PRs, disclaimer, and privacy links
4. Resize to tablet and phone widths