### PR TITLE
Fix retro terminal showing wrong blog post (reload & exit)

### DIFF
--- a/components/RetroTerminal.tsx
+++ b/components/RetroTerminal.tsx
@@ -48,14 +48,6 @@ function readStoredTerminalState(): StoredTerminalState | null {
   }
 }
 
-function storedShowWindows(posts: PostFrontMatter[], stored: StoredTerminalState | null, vw: number, vh: number): WinState[] {
-  if (vw < 640) return [];
-  const slugs = new Set(posts.map((post) => post.slug));
-  return (stored?.windows ?? [])
-    .filter((win) => win.id.startsWith('show:') && slugs.has(win.id.slice('show:'.length)))
-    .map((win) => clampWinToViewport(win, vw, vh));
-}
-
 function initialPostSlug(posts: PostFrontMatter[]): string | null {
   if (globalThis.location === undefined) return null;
   const { pathname } = new URL(globalThis.location.href);
@@ -104,9 +96,6 @@ export default function RetroTerminal({
   const [states, setStates] = useState<Record<string, WinState>>(() => {
     const g = termGeom(vw, vh, posts);
     const next: Record<string, WinState> = { [TERM_ID]: { id: TERM_ID, ...g, z: 1 } };
-    for (const win of storedShowWindows(posts, stored, vw, vh)) {
-      next[win.id] = win;
-    }
     if (urlPostSlug) {
       const id = showWinId(urlPostSlug);
       next[id] = { ...(next[id] ?? { id, ...showGeom(vw, vh) }), z: maxZof(next) + 1 };
@@ -140,9 +129,8 @@ export default function RetroTerminal({
 
   useEffect(() => {
     if (globalThis.localStorage === undefined) return;
-    const windows = Object.values(states).filter((win) => win.id.startsWith('show:'));
-    globalThis.localStorage.setItem(STORAGE_KEY, JSON.stringify({ cursor, windows }));
-  }, [cursor, states]);
+    globalThis.localStorage.setItem(STORAGE_KEY, JSON.stringify({ cursor }));
+  }, [cursor]);
 
   const focus = useCallback((id: string) => {
     setStates((prev) => {

--- a/components/RetroTerminal.tsx
+++ b/components/RetroTerminal.tsx
@@ -125,6 +125,20 @@ export default function RetroTerminal({
     globalThis.localStorage.setItem(STORAGE_KEY, JSON.stringify({ cursor }));
   }, [cursor]);
 
+  useEffect(() => {
+    if (globalThis.location === undefined) return;
+    let top: WinState | null = null;
+    for (const win of Object.values(states)) {
+      if (win.id.startsWith('show:') && (top === null || win.z > top.z)) {
+        top = win;
+      }
+    }
+    const desiredSlug = top ? top.id.slice('show:'.length) : null;
+    const { pathname } = new URL(globalThis.location.href);
+    const currentSlug = pathname.startsWith('/blog/') ? pathname.slice('/blog/'.length) : null;
+    if (desiredSlug !== currentSlug) updatePostUrl(desiredSlug);
+  }, [states]);
+
   const focus = useCallback((id: string) => {
     setStates((prev) => {
       const w = prev[id];
@@ -152,16 +166,6 @@ export default function RetroTerminal({
       return next;
     });
   }, []);
-
-  const closeShow = useCallback((id: string) => {
-    close(id);
-    const slug = id.slice('show:'.length);
-    if (globalThis.location !== undefined) {
-      const currentPath = new URL(globalThis.location.href).pathname;
-      const currentSlug = currentPath === `/blog/${slug}` ? slug : null;
-      if (currentSlug === slug) updatePostUrl(null);
-    }
-  }, [close]);
 
   const move = useCallback((id: string, x: number, y: number) => {
     setStates((prev) => {
@@ -303,7 +307,6 @@ export default function RetroTerminal({
     loadMdx(post.slug);
     open(showWinId(post.slug), showGeom(vw, vh));
     setCursor(i);
-    updatePostUrl(post.slug);
   };
 
   const openBlogSlug = useCallback((slug: string) => {
@@ -312,7 +315,6 @@ export default function RetroTerminal({
     loadMdx(slug);
     open(showWinId(slug), showGeom(vw, vh));
     setCursor(index);
-    updatePostUrl(slug);
     return true;
   }, [loadMdx, open, posts, vh, vw]);
 
@@ -470,7 +472,7 @@ export default function RetroTerminal({
                 active={active}
                 post={post}
                 mdxState={mdxBySlug[slug]}
-                onClose={() => closeShow(win.id)}
+                onClose={() => close(win.id)}
                 onActivate={() => focus(win.id)}
                 dragProps={titleDragProps(win.id)}
                 resizeProps={resizeHandleProps(win.id)}

--- a/components/RetroTerminal.tsx
+++ b/components/RetroTerminal.tsx
@@ -56,9 +56,20 @@ function initialPostSlug(posts: PostFrontMatter[]): string | null {
   return slug && posts.some((post) => post.slug === slug) ? slug : null;
 }
 
-function updatePostUrl(slug: string | null) {
+function pathForWindow(id: string | null) {
+  if (id?.startsWith('show:')) return `/blog/${id.slice('show:'.length)}`;
+  if (id?.startsWith('legal:')) {
+    const variant = id.slice('legal:'.length);
+    if (variant === 'disclaimer' || variant === 'privacy-policy') return `/${variant}`;
+  }
+  return '/';
+}
+
+function updateWindowUrl(id: string | null) {
   if (globalThis.location === undefined || globalThis.history === undefined) return;
-  const nextPath = slug ? `/blog/${slug}` : '/';
+  const nextPath = pathForWindow(id);
+  const { pathname } = new URL(globalThis.location.href);
+  if (pathname === nextPath) return;
   globalThis.history.replaceState(globalThis.history.state, '', nextPath);
 }
 
@@ -129,14 +140,11 @@ export default function RetroTerminal({
     if (globalThis.location === undefined) return;
     let top: WinState | null = null;
     for (const win of Object.values(states)) {
-      if (win.id.startsWith('show:') && (top === null || win.z > top.z)) {
+      if (top === null || win.z > top.z) {
         top = win;
       }
     }
-    const desiredSlug = top ? top.id.slice('show:'.length) : null;
-    const { pathname } = new URL(globalThis.location.href);
-    const currentSlug = pathname.startsWith('/blog/') ? pathname.slice('/blog/'.length) : null;
-    if (desiredSlug !== currentSlug) updatePostUrl(desiredSlug);
+    updateWindowUrl(top?.id ?? null);
   }, [states]);
 
   const focus = useCallback((id: string) => {

--- a/components/RetroTerminal.tsx
+++ b/components/RetroTerminal.tsx
@@ -62,12 +62,6 @@ function updatePostUrl(slug: string | null) {
   globalThis.history.replaceState(globalThis.history.state, '', nextPath);
 }
 
-function currentPathWithSearchAndHash() {
-  if (globalThis.location === undefined) return '/';
-  const { pathname, search, hash } = new URL(globalThis.location.href);
-  return `${pathname}${search}${hash}`;
-}
-
 function useViewport() {
   const [size, setSize] = useState(() => ({
     w: typeof globalThis.innerWidth === 'number' ? globalThis.innerWidth : 1200,
@@ -91,7 +85,6 @@ export default function RetroTerminal({
   const bounds: WinGeom = { x: 0, y: 0, w: vw, h: vh };
   const stored = useMemo(() => readStoredTerminalState(), []);
   const urlPostSlug = useMemo(() => initialPostSlug(posts), [posts]);
-  const entryPath = useRef(currentPathWithSearchAndHash());
 
   const [states, setStates] = useState<Record<string, WinState>>(() => {
     const g = termGeom(vw, vh, posts);
@@ -529,7 +522,6 @@ export default function RetroTerminal({
           className="retro-toggle retro-toggle--retro retro-terminal-exit"
           onClick={() => {
             setRetro(false);
-            globalThis.history.replaceState(globalThis.history.state, '', entryPath.current);
             globalThis.location.reload();
           }}
           aria-label="Exit terminal mode"

--- a/components/RetroTerminal.tsx
+++ b/components/RetroTerminal.tsx
@@ -56,6 +56,14 @@ function initialPostSlug(posts: PostFrontMatter[]): string | null {
   return slug && posts.some((post) => post.slug === slug) ? slug : null;
 }
 
+function initialLegalVariant(): LegalWindowVariant | null {
+  if (globalThis.location === undefined) return null;
+  const { pathname } = new URL(globalThis.location.href);
+  if (pathname === '/disclaimer') return 'disclaimer';
+  if (pathname === '/privacy-policy') return 'privacy-policy';
+  return null;
+}
+
 function pathForWindow(id: string | null) {
   if (id?.startsWith('show:')) return `/blog/${id.slice('show:'.length)}`;
   if (id?.startsWith('legal:')) {
@@ -96,6 +104,7 @@ export default function RetroTerminal({
   const bounds: WinGeom = { x: 0, y: 0, w: vw, h: vh };
   const stored = useMemo(() => readStoredTerminalState(), []);
   const urlPostSlug = useMemo(() => initialPostSlug(posts), [posts]);
+  const urlLegalVariant = useMemo(() => initialLegalVariant(), []);
 
   const [states, setStates] = useState<Record<string, WinState>>(() => {
     const g = termGeom(vw, vh, posts);
@@ -103,6 +112,10 @@ export default function RetroTerminal({
     if (urlPostSlug) {
       const id = showWinId(urlPostSlug);
       next[id] = { ...(next[id] ?? { id, ...showGeom(vw, vh) }), z: maxZof(next) + 1 };
+    }
+    if (urlLegalVariant) {
+      const id = legalWinId(urlLegalVariant);
+      next[id] = { id, ...legalGeom(vw, vh), z: maxZof(next) + 1 };
     }
     return next;
   });


### PR DESCRIPTION
## Summary

Fix retro terminal URL/window-state mismatches where the browser location could point to the wrong page.

1. **Reload of `/` re-opened the last-viewed post.** Open `show:<slug>` windows were persisted to `localStorage` and rehydrated on every mount, so they reappeared even with no slug in the URL.
2. **Exiting terminal mode restored the entry URL instead of the current one.** The exit button captured the URL at mount (`entryPath`) and force-restored it on exit, so browsing to other windows then exiting jumped back to the entry page.
3. **Focused terminal windows did not always drive the URL.** Focusing an already-open post/legal/etc. window could leave the URL pointing at a different window.
4. **Legal deep-links in terminal mode did not open legal windows.** Loading `/disclaimer` or `/privacy-policy` with retro mode enabled rendered the terminal but did not seed the matching legal window.

## Changes

All in `components/RetroTerminal.tsx`.

- Removed persisted `show:` window rehydration and only persist `cursor`.
- Removed `entryPath` restoration from the terminal exit button.
- Added focused-window URL sync derived from the highest-`z` terminal window:
  - `show:<slug>` -> `/blog/<slug>`
  - `legal:disclaimer` -> `/disclaimer`
  - `legal:privacy-policy` -> `/privacy-policy`
  - archive terminal and latest PRs -> `/`
- Added initial legal-window detection for `/disclaimer` and `/privacy-policy`.
- Centralized URL sync through `pathForWindow()` / `updateWindowUrl()`.

Deep-links to `/blog/<slug>`, `/disclaimer`, and `/privacy-policy` now open the matching retro terminal window.

## Test plan

- [x] Open a post in retro mode, navigate to `/` — post window no longer reappears
- [x] Inject stale `show:` windows into `localStorage`, reload `/` — not restored
- [x] Reload `/blog/<slug>` directly — post opens
- [x] Toggle retro on/off while on `/blog/<slug>` — post opens/closes correctly
- [x] Enter retro on post A, open post B, exit — stays on post B, not A
- [x] Focus archive terminal while a post is open — URL changes to `/`
- [x] Focus Privacy Policy window — URL changes to `/privacy-policy`
- [x] Focus latest PRs window — URL changes to `/`
- [x] Focus an existing blog post window — URL changes to `/blog/<slug>`
- [x] Load `/disclaimer?retro=1` — opens `legal:disclaimer`
- [x] Load `/privacy-policy?retro=1` — opens `legal:privacy-policy`
- [x] `pnpm type-check` and `pnpm lint` pass